### PR TITLE
[Bugfix] use headerValue which is correctly stringified rather the heade...

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,8 +45,8 @@ module.exports = {
       res.removeHeader('Content-Security-Policy-Report-Only');
       res.removeHeader('X-Content-Security-Policy-Report-Only');
 
-      res.setHeader(header, headerConfig);
-      res.setHeader('X-' + header, headerConfig);
+      res.setHeader(header, headerValue);
+      res.setHeader('X-' + header, headerValue);
 
       next();
     });


### PR DESCRIPTION
...rConfig which becomes stringified as `[object Object]`
