### PR TITLE
add a default `media-src`

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,8 @@ module.exports = {
         'font-src': "'self'",
         'connect-src': "'self'",
         'img-src': "'self'",
-        'style-src': "'self'"
+        'style-src': "'self'",
+        'media-src': "'self'"
       }
     }
 


### PR DESCRIPTION
`media-src` is used for audio/video elements. See https://developer.mozilla.org/en-US/docs/Web/Security/CSP/Using_Content_Security_Policy#Example_3.

This adds a reasonable default.
