### PR TITLE
I hope this only applies to the server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ember-cli-content-security-policy
 
 This addon adds the `Content-Security-Policy` header to response sent from the Ember CLI Express server.
-Clearly, Ember CLI is not intended for production use, and neither is this addon. This is intended as a
+Clearly, Ember CLI's express server is not intended for production use, and neither is this addon. This is intended as a
 tool to ensure that CSP is kept in the forefront of your thoughts while developing an Ember application.
 
 ## Options


### PR DESCRIPTION
This one I could do from within GH ;-)

Changes

> Clearly, Ember CLI is not intended for production use, and neither is this addon. 

To 

> Clearly, Ember CLI's express server is not intended for production use, and neither is this addon
