### PR TITLE
[WIP] Add report-uri

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,11 @@ module.exports = {
         });
       }
 
+      if (header.indexOf('Report-Only')!==-1 && !('report-uri' in headerConfig)) {
+        headerConfig['connect-src'] = headerConfig['connect-src'] + ' http://' + options.host +':' + options.port + '/csp-report';
+        headerConfig['report-uri'] = 'http://' + options.host +':' + options.port + '/csp-report'; 
+      }
+
       var headerValue = Object.keys(headerConfig).reduce(function(memo, value) {
         return memo + value + ' ' + headerConfig[value] + '; ';
       }, '');
@@ -60,6 +65,13 @@ module.exports = {
       res.setHeader('X-' + header, headerValue);
 
       next();
+    });
+
+    var bodyParser = require('body-parser');
+    app.use('/csp-report', bodyParser.json({type:'application/csp-report'}));
+    app.use('/csp-report', function(req, res, next) {
+      console.log('Content Security Policy violation: ' + JSON.stringify(req.body));
+      res.send({status:'ok'});
     });
   }
 };

--- a/package.json
+++ b/package.json
@@ -17,8 +17,10 @@
   },
   "author": "",
   "license": "MIT",
+  "dependencies": {
+    "body-parser": "^1.2.0"
+  },
   "devDependencies": {
-    "body-parser": "^1.2.0",
     "broccoli-asset-rev": "0.3.0",
     "broccoli-ember-hbs-template-compiler": "^1.6.1",
     "ember-cli": "0.1.0",


### PR DESCRIPTION
Fixes #12 
- Adds a `report-uri` header which defaults to host:port.
- Now just silently returns `{"status":"ok"}` to all requests on `/csp-report`
