### PR TITLE
list directives in a list instead of a long string

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ The default `contentSecurityPolicy` value is:
 
 ```javascript
   contentSecurityPolicy: {
-    'default-src': "'none'",
-    'script-src': "'self'",
-    'font-src': "'self'",
-    'connect-src': "'self'",
-    'img-src': "'self'",
-    'style-src': "'self'",
-    'media-src': "'self'"
+    'default-src': ["'none'"],
+    'script-src': ["'self'"],
+    'font-src': ["'self'"],
+    'connect-src': ["'self'"],
+    'img-src': ["'self'"],
+    'style-src': ["'self'"],
+    'media-src': ["'self'"]
   }
 ```
 
@@ -44,13 +44,18 @@ If your site uses **Google Fonts**, **Mixpanel**, a custom API at **custom-api.l
 ```javascript
 // config/environment.js
 ENV.contentSecurityPolicy = {
-  'default-src': "'none'",
-  'script-src': "'self' https://cdn.mxpnl.com", // Allow scripts from https://cdn.mxpnl.com
-  'font-src': "'self' http://fonts.gstatic.com", // Allow fonts to be loaded from http://fonts.gstatic.com
-  'connect-src': "'self' https://api.mixpanel.com http://custom-api.local", // Allow data (ajax/websocket) from api.mixpanel.com and custom-api.local
-  'img-src': "'self'",
-  'style-src': "'self' 'unsafe-inline' http://fonts.googleapis.com", // Allow inline styles and loaded CSS from http://fonts.googleapis.com 
-  'media-src': "'self'"
+  'default-src': ["'none'"],
+  'script-src': ["'self'",
+                 "https://cdn.mxpnl.com"], // Allow scripts from https://cdn.mxpnl.com
+  'font-src': ["'self'",
+               "http://fonts.gstatic.com"], // Allow fonts to be loaded from http://fonts.gstatic.com
+  'connect-src': ["'self'",
+                  "https://api.mixpanel.com http://custom-api.local"], // Allow data (ajax/websocket) from api.mixpanel.com and custom-api.local
+  'img-src': ["'self'"],
+  'style-src': ["'self'",
+                "'unsafe-inline'", // Allow inline styles
+                "http://fonts.googleapis.com"], // and loaded CSS from http://fonts.googleapis.com 
+  'media-src': ["'self'"]
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -35,9 +35,9 @@ module.exports = {
       Object.keys(headerConfig).forEach(function(key) {
         var policy = headerConfig[key];
         if ( typeof policy === "string" || policy instanceof String ) {
-          ui.writeLine('Warning: Content Security Policy');
-          ui.writeLine('Deprecated string format for: ' + key);
-          ui.writeLine('Use an array of strings instead.');
+          ui.writeLine(chalk.yellow('Warning: Content Security Policy'));
+          ui.writeLine(chalk.yellow('Deprecated string format for: ' + key));
+          ui.writeLine(chalk.yellow('Use an array of strings instead.'));
           headerConfig[key] = policy.split(/ +/);
         }
       });

--- a/index.js
+++ b/index.js
@@ -7,18 +7,18 @@ module.exports = {
     var ENV = {
       contentSecurityPolicyHeader: 'Content-Security-Policy-Report-Only',
       contentSecurityPolicy: {
-        'default-src': "'none'",
-        'script-src': "'self'",
-        'font-src': "'self'",
-        'connect-src': "'self'",
-        'img-src': "'self'",
-        'style-src': "'self'",
-        'media-src': "'self'"
+        'default-src': ["'none'"],
+        'script-src': ["'self'"],
+        'font-src': ["'self'"],
+        'connect-src': ["'self'"],
+        'img-src': ["'self'"],
+        'style-src': ["'self'"],
+        'media-src': ["'self'"]
       }
     };
 
     if (environment === 'development') {
-      ENV.contentSecurityPolicy['script-src'] = ENV.contentSecurityPolicy['script-src'] + " 'unsafe-eval'";
+      ENV.contentSecurityPolicy['script-src'].push("'unsafe-eval'");
     }
 
     return ENV;
@@ -28,28 +28,48 @@ module.exports = {
     var app = config.app;
     var options = config.options;
     var project = options.project;
+    var ui = this.ui;
+
+    // provide compatibility with the string format
+    function directiveStringsToLists(headerConfig) {
+      Object.keys(headerConfig).forEach(function(key) {
+        var policy = headerConfig[key];
+        if ( typeof policy === "string" || policy instanceof String ) {
+          ui.writeLine('Warning: Content Security Policy');
+          ui.writeLine('Deprecated string format for: ' + key);
+          ui.writeLine('Use an array of strings instead.');
+          headerConfig[key] = policy.split(/ +/);
+        }
+      });
+     
+      return headerConfig;
+    };
 
     app.use(function(req, res, next) {
       var appConfig = project.config(options.environment);
 
       var header = appConfig.contentSecurityPolicyHeader;
-      var headerConfig = appConfig.contentSecurityPolicy;
+      var headerConfig = directiveStringsToLists(appConfig.contentSecurityPolicy);
       var normalizedHost = options.host === '0.0.0.0' ? 'localhost' : options.host;
 
       if (options.liveReload) {
         ['localhost', '0.0.0.0'].forEach(function(host) {
-          headerConfig['connect-src'] = headerConfig['connect-src'] + ' ws://' + host + ':' + options.liveReloadPort;
-          headerConfig['script-src'] = headerConfig['script-src'] + ' ' + host + ':' + options.liveReloadPort;
+          headerConfig['connect-src'].push('ws://' + host + ':' + options.liveReloadPort);
+          headerConfig['script-src'].push(host + ':' + options.liveReloadPort);
         });
       }
 
       if (header.indexOf('Report-Only')!==-1 && !('report-uri' in headerConfig)) {
-        headerConfig['connect-src'] = headerConfig['connect-src'] + ' http://' + normalizedHost + ':' + options.port + '/csp-report';
-        headerConfig['report-uri'] = 'http://' + normalizedHost + ':' + options.port + '/csp-report';
+        headerConfig['connect-src'].push('http://' + normalizedHost + ':' + options.port + '/csp-report');
+        headerConfig['report-uri'] = ['http://' + normalizedHost + ':' + options.port + '/csp-report'];
       }
 
       var headerValue = Object.keys(headerConfig).reduce(function(memo, value) {
-        return memo + value + ' ' + headerConfig[value] + '; ';
+        var flattenedList = headerConfig[value].reduce(function(preV, curV) {
+          return preV + ' ' + curV;
+        }, '');
+
+        return memo + value + ' ' + flattenedList + '; ';
       }, '');
 
       if (!header || !headerValue) {


### PR DESCRIPTION
Same intent as in https://github.com/rwjblue/ember-cli-content-security-policy/pull/15, but coming from a branch and with a couple of tweaks.

Instead of:

    'script-src': "'self' https://cdn.mxpnl.com https://cdn.foobar.com"

Do:

    'script-src': ["'self'",
                   "https://cdn.mxpnl.com",
                   "https://cdn.foobar.com"]

Handles:

    contentSecurityPolicy: {
        'style-src': ["'self'", "'unsafe-inline'"],
        'frame-src': "'self' http://disqus.com"                                    
    }

And prints a deprecation warning to the server.