### PR TITLE
fixes twitter bootstrap script for ember-cli plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = {
     }
 
     if (environment === 'development') {
-      ENV.contentSecurityPolicy['script-src'] = ENV.contentSecurityPolicy['script-src'] + " 'unsafe-eval'";
+      ENV.contentSecurityPolicy['script-src'] = ENV.contentSecurityPolicy['script-src'] + " 'unsafe-eval' 'unsafe-inline'";
     }
 
     return ENV;


### PR DESCRIPTION
Twitter bootstrap blows up the console and the ember-cli server output without this, `'unsafe-inline'`.  Would this introduce an attack vector?
