### PR TITLE
Use of domain-alias in development

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,15 @@ ENV.contentSecurityPolicy = {
   'font-src': "'self' http://fonts.gstatic.com", // Allow fonts to be loaded from http://fonts.gstatic.com
   'connect-src': "'self' https://api.mixpanel.com http://custom-api.local", // Allow data (ajax/websocket) from api.mixpanel.com and custom-api.local
   'img-src': "'self'",
-  'style-src': "'self' 'unsafe-inline' http://fonts.googleapis.com", // Allow inline styles and loaded CSS from http://fonts.googleapis.com 
+  'style-src': "'self' 'unsafe-inline' http://fonts.googleapis.com", // Allow inline styles and loaded CSS from http://fonts.googleapis.com
   'media-src': "'self'"
 }
+```
+
+If you are using a domain alias in your develoment environment (maybe for testing subdomain related functionalities) you should white-label it for livereload:
+```
+// config/environment.js
+ENV.liveReloadHosts = ['*domain.ext']
 ```
 
 More information on these options can be found at [content-security-policy.com](http://content-security-policy.com/)

--- a/README.md
+++ b/README.md
@@ -54,10 +54,10 @@ ENV.contentSecurityPolicy = {
 }
 ```
 
-If you are using a domain alias in your develoment environment (maybe for testing subdomain related functionalities) you should white-label it for livereload:
-```
+If you are using a **domain alias** in your develoment environment (perhaps for testing subdomain related functionalities) you should white-list it for livereload:
+```javascript
 // config/environment.js
-ENV.liveReloadHosts = ['*domain.ext']
+ENV.liveReloadHosts = ['*.domain.ext']
 ```
 
 More information on these options can be found at [content-security-policy.com](http://content-security-policy.com/)

--- a/index.js
+++ b/index.js
@@ -12,7 +12,8 @@ module.exports = {
         'img-src': "'self'",
         'style-src': "'self'",
         'media-src': "'self'"
-      }
+      },
+      liveReloadHosts: ['localhost', '0.0.0.0']
     }
 
     if (environment === 'development') {
@@ -35,7 +36,7 @@ module.exports = {
       var headerConfig = appConfig.contentSecurityPolicy;
 
       if (options.liveReload) {
-        ['localhost', '0.0.0.0'].forEach(function(host) {
+        appConfig.liveReloadHosts.forEach(function(host) {
           headerConfig['connect-src'] = headerConfig['connect-src'] + ' ws://' + host + ':' + options.liveReloadPort;
           headerConfig['script-src'] = headerConfig['script-src'] + ' ' + host + ':' + options.liveReloadPort;
         });
@@ -43,7 +44,7 @@ module.exports = {
 
       if (header.indexOf('Report-Only')!==-1 && !('report-uri' in headerConfig)) {
         headerConfig['connect-src'] = headerConfig['connect-src'] + ' http://' + options.host +':' + options.port + '/csp-report';
-        headerConfig['report-uri'] = 'http://' + options.host +':' + options.port + '/csp-report'; 
+        headerConfig['report-uri'] = 'http://' + options.host +':' + options.port + '/csp-report';
       }
 
       var headerValue = Object.keys(headerConfig).reduce(function(memo, value) {


### PR DESCRIPTION
Allows to specify an array of white-listed domain alias in local development: 

```bash
# /etc/host
127.0.0.1	localhost

127.0.0.1       sub1.myDomain.ext
127.0.0.1       sub2.myDomain.ext
```

```javascript
// config/environment.js
ENV.liveReloadHosts = ['*.myDomain.ext']
```