### PR TITLE
Normalize options.host so report-uri works on windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ module.exports = {
 
       var header = appConfig.contentSecurityPolicyHeader;
       var headerConfig = appConfig.contentSecurityPolicy;
+      var normalizedHost = options.host === '0.0.0.0' ? 'localhost' : options.host;
 
       if (options.liveReload) {
         ['localhost', '0.0.0.0'].forEach(function(host) {
@@ -41,8 +42,8 @@ module.exports = {
       }
 
       if (header.indexOf('Report-Only')!==-1 && !('report-uri' in headerConfig)) {
-        headerConfig['connect-src'] = headerConfig['connect-src'] + ' http://' + options.host + ':' + options.port + '/csp-report';
-        headerConfig['report-uri'] = 'http://' + options.host + ':' + options.port + '/csp-report';
+        headerConfig['connect-src'] = headerConfig['connect-src'] + ' http://' + normalizedHost + ':' + options.port + '/csp-report';
+        headerConfig['report-uri'] = 'http://' + normalizedHost + ':' + options.port + '/csp-report';
       }
 
       var headerValue = Object.keys(headerConfig).reduce(function(memo, value) {


### PR DESCRIPTION
Fixes #36
Didn't touch the live reload host as it looks like that's hard coded to localhost and 0.0.0.0 for some reason.  Should that be fixed in the future?