### PR TITLE
Inject http-equiv metatag into head

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ used from your projects configuration:
 * `contentSecurityPolicy` -- This is an object that is used to build the final header value. Each key/value
   in this object is converted into a key/value pair in the resulting header value.
 
+* `contentSecurityPolicyMetatag` -- If true a meta tag will be injected into the head of index.html. Default: false.
+
+  `<meta http-equiv="Content-Security-Policy" content="{csp-directives}"/>`
+
 The default `contentSecurityPolicy` value is:
 
 ```javascript

--- a/index.js
+++ b/index.js
@@ -1,3 +1,40 @@
+var _headerData = function(config) {
+  var options = config.options;
+  var project = options.project;
+
+  var appConfig = project.config(options.environment);
+
+
+  var header = appConfig.contentSecurityPolicyHeader;
+  var headerConfig = appConfig.contentSecurityPolicy;
+  var normalizedHost = options.host === '0.0.0.0' ? 'localhost' : options.host;
+
+  if (options.liveReload) {
+    ['localhost', '0.0.0.0'].forEach(function(host) {
+      headerConfig['connect-src'] = headerConfig['connect-src'] + ' ws://' + host + ':' + options.liveReloadPort;
+      headerConfig['script-src'] = headerConfig['script-src'] + ' ' + host + ':' + options.liveReloadPort;
+    });
+  }
+
+  if (header.indexOf('Report-Only')!==-1 && !('report-uri' in headerConfig)) {
+    headerConfig['connect-src'] = headerConfig['connect-src'] + ' http://' + normalizedHost + ':' + options.port + '/csp-report';
+    headerConfig['report-uri'] = 'http://' + normalizedHost + ':' + options.port + '/csp-report';
+  }
+
+  var headerValue = Object.keys(headerConfig).reduce(function(memo, value) {
+    return memo + value + ' ' + headerConfig[value] + '; ';
+  }, '');
+
+  if (!header || !headerValue) {
+    return;
+  }
+
+  return {
+    header: header,
+    headerValue: headerValue
+  };
+};
+
 module.exports = {
   name: 'ember-cli-content-security-policy',
 
@@ -24,31 +61,11 @@ module.exports = {
 
   serverMiddleware: function(config) {
     var app = config.app;
-    var options = config.options;
-    var project = options.project;
 
     app.use(function(req, res, next) {
-      var appConfig = project.config(options.environment);
-
-      var header = appConfig.contentSecurityPolicyHeader;
-      var headerConfig = appConfig.contentSecurityPolicy;
-      var normalizedHost = options.host === '0.0.0.0' ? 'localhost' : options.host;
-
-      if (options.liveReload) {
-        ['localhost', '0.0.0.0'].forEach(function(host) {
-          headerConfig['connect-src'] = headerConfig['connect-src'] + ' ws://' + host + ':' + options.liveReloadPort;
-          headerConfig['script-src'] = headerConfig['script-src'] + ' ' + host + ':' + options.liveReloadPort;
-        });
-      }
-
-      if (header.indexOf('Report-Only')!==-1 && !('report-uri' in headerConfig)) {
-        headerConfig['connect-src'] = headerConfig['connect-src'] + ' http://' + normalizedHost + ':' + options.port + '/csp-report';
-        headerConfig['report-uri'] = 'http://' + normalizedHost + ':' + options.port + '/csp-report';
-      }
-
-      var headerValue = Object.keys(headerConfig).reduce(function(memo, value) {
-        return memo + value + ' ' + headerConfig[value] + '; ';
-      }, '');
+      var headerData = _headerData(config),
+         headerValue = headerData.headerValue,
+              header = headerData.header;
 
       if (!header || !headerValue) {
         next();

--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ module.exports = {
   },
 
   contentFor: function(type, config) {
-    if (type === 'head') {
+    if (type === 'head' && config.contentSecurityPolicyMetatag) {
       var headerData = _headerData(config),
          headerValue = headerData.headerValue,
               header = headerData.header;

--- a/index.js
+++ b/index.js
@@ -1,9 +1,7 @@
-var _headerData = function(config) {
-  var options = config.options;
-  var project = options.project;
-
-  var appConfig = project.config(options.environment);
-
+var _headerData = function(appConfig, options) {
+  if (!options) {
+    options = {};
+  }
 
   var header = appConfig.contentSecurityPolicyHeader;
   var headerConfig = appConfig.contentSecurityPolicy;
@@ -63,7 +61,12 @@ module.exports = {
     var app = config.app;
 
     app.use(function(req, res, next) {
-      var headerData = _headerData(config),
+      var options = config.options;
+      var project = options.project;
+
+      var appConfig = project.config(options.environment);
+
+      var headerData = _headerData(appConfig, options),
          headerValue = headerData.headerValue,
               header = headerData.header;
 
@@ -91,5 +94,15 @@ module.exports = {
       console.log('Content Security Policy violation: ' + JSON.stringify(req.body));
       res.send({status:'ok'});
     });
+  },
+
+  contentFor: function(type, config) {
+    if (type === 'head') {
+      var headerData = _headerData(config),
+         headerValue = headerData.headerValue,
+              header = headerData.header;
+
+      return '<meta http-equiv="' + header + '" content="' + headerValue + '">';
+    }
   }
 };

--- a/index.js
+++ b/index.js
@@ -59,11 +59,10 @@ module.exports = {
 
   serverMiddleware: function(config) {
     var app = config.app;
+    var options = config.options;
+    var project = options.project;
 
     app.use(function(req, res, next) {
-      var options = config.options;
-      var project = options.project;
-
       var appConfig = project.config(options.environment);
 
       var headerData = _headerData(appConfig, options),


### PR DESCRIPTION
As seen in [this issue][1], as of iOS 7, you may provide Content-Security-Policy in a metatag. This makes it possible to enable security measures provided by CSP in environments where headers simply aren't present (like phonegap).

I'm using the `addon.contentFor` hook to inject the meta tag. The content should be more or less equivalent to what is served from `ember serve`, with the exception that you'll have to explicitly provide the `report-uri` directive (though I'm not sure if this directive will be used in a local environment).

I don't see this PR as ready to merge, but I would like some input.

What should be done:
- [ ] Refactor `_headerData` with a better argument list
- [x] Make the meta tag opt-in with some configuration variable

[1]: https://github.com/MobileChromeApps/mobile-chrome-apps/issues/73