### PR TITLE
Enable use of CSPs fallback mechanism

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,11 @@ module.exports = {
       }
 
       var headerValue = Object.keys(headerConfig).reduce(function(memo, value) {
-        return memo + value + ' ' + headerConfig[value] + '; ';
+        if (value === null || value === undefined) {
+          return memo;
+        } else {
+          return memo + value + ' ' + headerConfig[value] + '; ';
+        }
       }, '');
 
       if (!header || !headerValue) {


### PR DESCRIPTION
With this change, clearing a default entry is possible by setting it's value to `null`.

***

CSP is nifty and can fall-back to `default-src`. For example, if `font-src` isn't specified it'll use the value in `default-src`.

Currently (in this addon), `font-src` is always specified and cannot be cleared. This leads to verbose configuration, for example: 

```
var defaultHosts = ['my', 'default', 'hosts'];
ENV.contentSecurityPolicy = {
  'default-src': defaultHosts.join(' '),
  'script-src': defaultHosts.join(' ') + " 'unsafe-eval'",
  // should fall-back to default when not specified, but that doesn't seem to work
  'font-src': defaultHosts.join(' '),
  'connect-src': defaultHosts.join(' '),
  'img-src': defaultHosts.join(' '),
  'style-src': defaultHosts.join(' '),
  'media-src': defaultHosts.join(' ')
};
```