### PR TITLE
A few improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,17 +17,19 @@ used from your projects configuration:
 * `contentSecurityPolicy` -- This is an object that is used to build the final header value. Each key/value
   in this object is converted into a key/value pair in the resulting header value.
 
+* `contentSecurityPolicyMeta` -- Boolean. Toggle delivery via meta-tag. Useful for deployments where headers are not available (mobile, S3, etc) or to tether the CSP policy to the client payload (i.e. policy can be updated without reconfiguring servers). Check the W3C resource for details.
+
 The default `contentSecurityPolicy` value is:
 
 ```javascript
   contentSecurityPolicy: {
-    'default-src': "'none'",
-    'script-src': "'self'",
-    'font-src': "'self'",
-    'connect-src': "'self'",
-    'img-src': "'self'",
-    'style-src': "'self'",
-    'media-src': "'self'"
+    'default-src': ["'none'"],
+    'script-src':  ["'self'"],
+    'font-src':    ["'self'"],
+    'connect-src': ["'self'"],
+    'img-src':     ["'self'"],
+    'style-src':   ["'self'"],
+    'media-src':   ["'self'"]
   }
 ```
 
@@ -37,6 +39,8 @@ Which is translated into:
 default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self';
 ```
 
+If a directive is omitted it will default to `'self'`. To clear a directive from the default policy above, set it to `null`. The browser will fallback to the `default-src` if a directive does not exist.
+
 ### Example
 
 If your site uses **Google Fonts**, **Mixpanel**, a custom API at **custom-api.local** and a jQuery plugin which modifies the inline `style` attribute of some elements:
@@ -45,12 +49,12 @@ If your site uses **Google Fonts**, **Mixpanel**, a custom API at **custom-api.l
 // config/environment.js
 ENV.contentSecurityPolicy = {
   'default-src': "'none'",
-  'script-src': "'self' https://cdn.mxpnl.com", // Allow scripts from https://cdn.mxpnl.com
-  'font-src': "'self' http://fonts.gstatic.com", // Allow fonts to be loaded from http://fonts.gstatic.com
-  'connect-src': "'self' https://api.mixpanel.com http://custom-api.local", // Allow data (ajax/websocket) from api.mixpanel.com and custom-api.local
+  'script-src': ["'self'", "https://cdn.mxpnl.com"], // Allow scripts from https://cdn.mxpnl.com
+  'font-src': ["'self'", "http://fonts.gstatic.com"], // Allow fonts to be loaded from http://fonts.gstatic.com
+  'connect-src': ["'self'", "https://api.mixpanel.com", "http://custom-api.local"], // Allow data (ajax/websocket) from api.mixpanel.com and custom-api.local
   'img-src': "'self'",
-  'style-src': "'self' 'unsafe-inline' http://fonts.googleapis.com", // Allow inline styles and loaded CSS from http://fonts.googleapis.com 
-  'media-src': "'self'"
+  'style-src': ["'self'", "'unsafe-inline'", "http://fonts.googleapis.com"], // Allow inline styles and loaded CSS from http://fonts.googleapis.com
+  'media-src': null // `media-src` will be omitted from policy, browser will fallback to default-src for media resources.
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -1,27 +1,64 @@
 var chalk = require('chalk');
 
+var buildPolicyString = require('./lib/utils')['buildPolicyString'];
+
+var CSP_SELF        = "'self'";
+var CSP_NONE        = "'none'";
+var REPORT_PATH     = '/csp-report';
+
+var CSP_HEADER              = 'Content-Security-Policy';
+var CSP_HEADER_REPORT_ONLY  = 'Content-Security-Policy-Report-Only';
+
+var CSP_REPORT_URI          = 'report-uri';
+var CSP_FRAME_ANCESTORS     = 'frame-ancestors';
+var CSP_SANDBOX             = 'sandbox';
+
+var META_UNSUPPORTED_DIRECTIVES = [
+  CSP_REPORT_URI,
+  CSP_FRAME_ANCESTORS,
+  CSP_SANDBOX,
+];
+
+var unsupportedDirectives = function(policyObject) {
+  return META_UNSUPPORTED_DIRECTIVES.filter(function(name) {
+    return policyObject && (name in policyObject);
+  });
+}
+
+var appendSourceList = function(policyObject, name, sourceList) {
+  var oldSourceList;
+  var oldValue = policyObject[name];
+
+  if (Array.isArray(oldValue)) {
+    oldSourceList = oldValue;
+  } else if (!oldValue) {
+    oldSourceList = [];
+  } else if (typeof oldValue === 'string') {
+    oldSourceList = oldValue.split(' ');
+  } else {
+    throw new Error('Unknown source list value');
+  }
+
+  oldSourceList.push(sourceList);
+  policyObject[name] = oldSourceList.join(' ');
+}
+
 module.exports = {
   name: 'ember-cli-content-security-policy',
 
-  config: function(environment /*, appConfig */) {
-    var ENV = {
-      contentSecurityPolicyHeader: 'Content-Security-Policy-Report-Only',
+  config: function(/* environment, appConfig */) {
+    return {
+      contentSecurityPolicyHeader: CSP_HEADER_REPORT_ONLY,
       contentSecurityPolicy: {
-        'default-src': "'none'",
-        'script-src': "'self'",
-        'font-src': "'self'",
-        'connect-src': "'self'",
-        'img-src': "'self'",
-        'style-src': "'self'",
-        'media-src': "'self'"
+        'default-src':  CSP_NONE,
+        'script-src':   CSP_SELF,
+        'font-src':     CSP_SELF,
+        'connect-src':  CSP_SELF,
+        'img-src':      CSP_SELF,
+        'style-src':    CSP_SELF,
+        'media-src':    CSP_SELF
       }
     };
-
-    if (environment === 'development') {
-      ENV.contentSecurityPolicy['script-src'] = ENV.contentSecurityPolicy['script-src'] + " 'unsafe-eval'";
-    }
-
-    return ENV;
   },
 
   serverMiddleware: function(config) {
@@ -33,48 +70,84 @@ module.exports = {
       var appConfig = project.config(options.environment);
 
       var header = appConfig.contentSecurityPolicyHeader;
-      var headerConfig = appConfig.contentSecurityPolicy;
-      var normalizedHost = options.host === '0.0.0.0' ? 'localhost' : options.host;
+      var policyObject = appConfig.contentSecurityPolicy;
 
+      // can be moved to the ember-cli-live-reload addon if RFC-22 is implemented
+      // https://github.com/ember-cli/rfcs/pull/22
       if (options.liveReload) {
         ['localhost', '0.0.0.0'].forEach(function(host) {
-          headerConfig['connect-src'] = headerConfig['connect-src'] + ' ws://' + host + ':' + options.liveReloadPort;
-          headerConfig['script-src'] = headerConfig['script-src'] + ' ' + host + ':' + options.liveReloadPort;
+          var liveReloadHost = host + ':' + options.liveReloadPort;
+          appendSourceList(policyObject, 'connect-src', 'ws://' + liveReloadHost);
+          appendSourceList(policyObject, 'script-src', liveReloadHost);
         });
       }
 
-      if (header.indexOf('Report-Only')!==-1 && !('report-uri' in headerConfig)) {
-        headerConfig['connect-src'] = headerConfig['connect-src'] + ' http://' + normalizedHost + ':' + options.port + '/csp-report';
-        headerConfig['report-uri'] = 'http://' + normalizedHost + ':' + options.port + '/csp-report';
+      // only needed for headers, since report-uri cannot be specified in meta tag
+      if (header.indexOf('Report-Only') !== -1 && !('report-uri' in policyObject)) {
+        var ecHost = options.host || 'localhost';
+        var ecProtocol = options.ssl ? 'https://' : 'http://';
+        var ecOrigin = ecProtocol + ecHost + ':' + options.port;
+        appendSourceList(policyObject, 'connect-src', ecOrigin);
+        policyObject['report-uri'] = ecOrigin + REPORT_PATH;
       }
 
-      var headerValue = Object.keys(headerConfig).reduce(function(memo, value) {
-        return memo + value + ' ' + headerConfig[value] + '; ';
-      }, '');
+      var headerValue = buildPolicyString(policyObject);
 
       if (!header || !headerValue) {
         next();
         return;
       }
 
-      res.removeHeader("Content-Security-Policy");
-      res.removeHeader("X-Content-Security-Policy");
-
-      res.removeHeader('Content-Security-Policy-Report-Only');
-      res.removeHeader('X-Content-Security-Policy-Report-Only');
-
+      // clear existing headers before setting ours
+      res.removeHeader(CSP_HEADER);
+      res.removeHeader(CSP_HEADER_REPORT_ONLY);
       res.setHeader(header, headerValue);
+
+      // for Internet Explorer 11 and below (Edge support the standard header name)
+      res.removeHeader('X-' + CSP_HEADER);
+      res.removeHeader('X-' + CSP_HEADER_REPORT_ONLY);
       res.setHeader('X-' + header, headerValue);
 
       next();
     });
 
     var bodyParser = require('body-parser');
-    app.use('/csp-report', bodyParser.json({type:'application/csp-report'}));
-    app.use('/csp-report', bodyParser.json({type:'application/json'}));
-    app.use('/csp-report', function(req, res, next) {
+    app.use(REPORT_PATH, bodyParser.json({ type: 'application/csp-report' }));
+    app.use(REPORT_PATH, bodyParser.json({ type: 'application/json' }));
+    app.use(REPORT_PATH, function(req, res, next) {
       console.log(chalk.red('Content Security Policy violation:') + '\n\n' + JSON.stringify(req.body, null, 2));
-      res.send({status:'ok'});
+      res.send({ status:'ok' });
     });
+  },
+
+  contentFor: function(type, appConfig) {
+    if ((type === 'head' && appConfig.contentSecurityPolicyMeta)) {
+      var policyObject = appConfig.contentSecurityPolicy;
+      var liveReloadPort = process.env.EMBER_CLI_INJECT_LIVE_RELOAD_PORT;
+
+      // can be moved to the ember-cli-live-reload addon if RFC-22 is implemented
+      // https://github.com/ember-cli/rfcs/pull/22
+      if (liveReloadPort) {
+        ['localhost', '0.0.0.0'].forEach(function(host) {
+          var liveReloadHost = host + ':' + liveReloadPort;
+          appendSourceList(policyObject, 'connect-src', 'ws://' + liveReloadHost);
+          appendSourceList(policyObject, 'script-src', liveReloadHost);
+        });
+      }
+
+      var policyString = buildPolicyString(policyObject);
+
+      unsupportedDirectives(policyObject).forEach(function(name) {
+        var msg = 'CSP deliverd via meta does not support `' + name + '`, ' +
+                  'per the W3C recommendation.';
+        console.log(chalk.yellow(msg));
+      });
+
+      if (!policyString) {
+        console.log(chalk.yellow('CSP via meta tag enabled but no policy exist.'));
+      } else {
+        return '<meta http-equiv="' + CSP_HEADER + '" content="' + policyString + '">';
+      }
+    }
   }
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,18 @@
+'use strict';
+
+var buildPolicyString = function(policyObject) {
+  return Object.keys(policyObject).reduce(function(memo, name) {
+    var value = policyObject[name];
+    if (value === null) {
+      // Override the default value of `'self'`. Instead no entry will be included
+      // in the CSP. This, in turn, will cause the CSP to fallback to `default-src`
+      // for this directive. http://www.w3.org/TR/CSP2/#default-src-usage
+      return memo;
+    } else {
+      var sourceList = Array.isArray(value) ? value.join(' ') : value;
+      return memo + name + ' ' + sourceList + '; ';
+    }
+  }, '');
+};
+
+module.exports = { buildPolicyString: buildPolicyString };


### PR DESCRIPTION
- Support serving CSP via meta tag.
- Break out policy generation into utility function.
- Enable overriding the default policy by setting a directive to `null`.
- Allow specifying the source list as an array.

None of these changes are breaking.

Fixes #21 and fixes #38.
Supersedes #51, #39, #41 and #20.

@rwjblue Let me know if you want me to change anything!