### PR TITLE
Consider CSP's built-in fallback mechanism

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,11 @@
+/* global module */
 'use strict';
+
+var unique = function(array) {
+  return array.filter(function(value, index, self) {
+    return self.indexOf(value) === index;
+  });
+};
 
 var buildPolicyString = function(policyObject) {
   return Object.keys(policyObject).reduce(function(memo, name) {
@@ -9,7 +16,7 @@ var buildPolicyString = function(policyObject) {
       // for this directive. http://www.w3.org/TR/CSP2/#default-src-usage
       return memo;
     } else {
-      var sourceList = Array.isArray(value) ? value.join(' ') : value;
+      var sourceList = Array.isArray(value) ? unique(value).join(' ') : value;
       return memo + name + ' ' + sourceList + '; ';
     }
   }, '');


### PR DESCRIPTION
CSP has a built-in fallback mechanism. If, say, `connect-src` is not defined it will fall back to `default-src`. This can cause issues when the addon appends to an empty directive.

An example:

    Developer has has defined the following policy:
    `default-src: 'self' example.com;`
    
    An xhr to example.com (the connect-src directive) will be allowed. 
    Since no connect-src directive is defined it will fallback to default-src.
    
    Then an addon appends the connect-src entry live-reload.local, and the result is:
    `default-src: 'self' example.com; connect-src: live-reload.local;`
    
    After the addons change an xhr to example.com (which was previously permitted, 
    via fallback to default-src) is now rejected since it doesn't match 'live-reload.local'.

This PR fixes this by copying from default-src before appending to an empty entry.