### PR TITLE
Fix: livereload violates csp if served via https

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,8 @@ module.exports = {
       if (options.liveReload) {
         ['localhost', '0.0.0.0'].forEach(function(host) {
           var liveReloadHost = host + ':' + options.liveReloadPort;
-          appendSourceList(policyObject, 'connect-src', 'ws://' + liveReloadHost);
+          var liveReloadProtocol = options.ssl ? 'wss://' : 'ws://';
+          appendSourceList(policyObject, 'connect-src', liveReloadProtocol + liveReloadHost);
           appendSourceList(policyObject, 'script-src', liveReloadHost);
         });
       }
@@ -155,7 +156,8 @@ module.exports = {
       if (policyObject && liveReloadPort) {
         ['localhost', '0.0.0.0'].forEach(function(host) {
           var liveReloadHost = host + ':' + liveReloadPort;
-          appendSourceList(policyObject, 'connect-src', 'ws://' + liveReloadHost);
+          var liveReloadProtocol = options.ssl ? 'wss://' : 'ws://';
+          appendSourceList(policyObject, 'connect-src', liveReloadProtocol + liveReloadHost);
           appendSourceList(policyObject, 'script-src', liveReloadHost);
         });
       }


### PR DESCRIPTION
As mentioned in a comment to PR #44 also livereload violates csp if page is served via https. 9fd84a51f0e2b73a6eb405bba0a26167822ccff7 only fixed #43 (csp violation by csp report uri, which was actually funny) but not csp violation by livereload.