### PR TITLE
Added the live reload host for setting of the security policies

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,7 +100,7 @@ module.exports = {
       // can be moved to the ember-cli-live-reload addon if RFC-22 is implemented
       // https://github.com/ember-cli/rfcs/pull/22
       if (options.liveReload) {
-        ['localhost', '0.0.0.0'].forEach(function(host) {
+        ['localhost', '0.0.0.0', options.liveReloadHost].forEach(function(host) {
           var liveReloadHost = host + ':' + options.liveReloadPort;
           var liveReloadProtocol = options.ssl ? 'wss://' : 'ws://';
           appendSourceList(policyObject, 'connect-src', liveReloadProtocol + liveReloadHost);


### PR DESCRIPTION
incase you are using a custom host for live reload, or for the general host. I know this could be changing when the live reload addon gets completed, and it's pulling from the addon rather then here. but thought this would still be a nice stop gap incase people are using custom hosts.