### PR TITLE
Add the new middleware name from ember-cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "configPath": "tests/dummy/config",
     "before": [
       "serve-files-middleware",
+      "broccoli-serve-files",
       "history-support-middleware",
       "proxy-server-middleware"
     ]


### PR DESCRIPTION
This addon should run before the files are served and after the build is done.