### PR TITLE
Don't include dist in published builds (2.5MB)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "doc": "doc",
     "test": "tests"
   },
+  "files": [
+    "!dist/"
+  ],
   "scripts": {
     "start": "ember server",
     "build": "ember build",


### PR DESCRIPTION
Noticed while grepping for addons using `lookupFactory` that this addon was including it's `dist/` folder in published builds. I added the `files: []` array here with a rule to exclude `dist`.