### PR TITLE
Don't include dist in published builds (2.5MB)

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,7 @@
 bower_components/
 tests/
 tmp/
+dist/
 
 .bowerrc
 .editorconfig


### PR DESCRIPTION
Noticed while grepping for addons using `lookupFactory` that this addon was including it's `dist/` folder in published builds. I added the `dist/` rule here to `.npmignore` to fix this.  Replaces #71