### PR TITLE
Add worker-src as a supported policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ The default `contentSecurityPolicy` value is:
     'connect-src': ["'self'"],
     'img-src':     ["'self'"],
     'style-src':   ["'self'"],
-    'media-src':   ["'self'"]
+    'media-src':   ["'self'"],
+    'worker-src':  ["'self'"]
   }
 ```
 

--- a/index.js
+++ b/index.js
@@ -77,6 +77,7 @@ module.exports = {
       'img-src':      [CSP_SELF],
       'style-src':    [CSP_SELF],
       'media-src':    [CSP_SELF],
+      'worker-src':   [CSP_SELF]
     };
 
     // testem requires frame-src to run


### PR DESCRIPTION
This will prevent getting CSP Error reports when using `ember-service-worker` such as this:

```[Report Only] Refused to create a worker from 'http://localhost:4200/sw.js' because it violates the following Content Security Policy directive: "default-src 'none'". Note that 'worker-src' was not explicitly set, so 'default-src' is used as a fallback.```