### PR TITLE
Move ember-cli-babel to dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,13 +19,13 @@
   },
   "dependencies": {
     "body-parser": "^1.17.0",
-    "chalk": "^2.0.0"
+    "chalk": "^2.0.0",
+    "ember-cli-babel": "^6.3.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
     "ember-ajax": "^3.0.0",
     "ember-cli": "~2.14.2",
-    "ember-cli-babel": "^6.3.0",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-eslint": "^3.0.0",
     "ember-cli-htmlbars": "^2.0.1",


### PR DESCRIPTION
Fix deprecation error when consuming ember-cli-content-security-policy.
```
DEPRECATION: Addon files were detected in `./node_modules/ember-cli-content-security-policy/addon`, but no JavaScript prepro
cessors were found for `ember-cli-content-security-policy`. Please make sure to add a preprocessor (most likely `ember-cli-babel`) to in `dependencies` (NOT `devDependencies`) in `e
mber-cli-content-security-policy`'s `package.json`.
```