### PR TITLE
Add option to output raw csp (fix #81)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "4"
+  - '8'
 
 sudo: false
 

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -19,8 +19,15 @@ module.exports = {
       },
       {
         name: 'report-uri',
-        type: String
-      }
+        type: String,
+        description: 'Sets report-uri for the policy'
+      },
+      {
+        name: 'silent',
+        type: Boolean,
+        default: false,
+        description: 'Only outputs the policy without the instructions for Apache and Nginx'
+      },
     ],
 
     run: function(options) {
@@ -31,10 +38,12 @@ module.exports = {
         config.contentSecurityPolicy['report-uri'] = reportUri;
       }
 
-      this.ui.writeLine(chalk.dim.cyan('# Content Security Policy Header Configuration'));
-      this.ui.writeLine(chalk.dim.cyan('#'));
-      this.ui.writeLine(chalk.dim.cyan('# for Apache: Header set ' + config.contentSecurityPolicyHeader + ' "..."'));
-      this.ui.writeLine(chalk.dim.cyan('# for Nginx : add_header ' + config.contentSecurityPolicyHeader + ' "...";') + '\n');
+      if (!options.silent) {
+        this.ui.writeLine(chalk.dim.cyan('# Content Security Policy Header Configuration'));
+        this.ui.writeLine(chalk.dim.cyan('#'));
+        this.ui.writeLine(chalk.dim.cyan('# for Apache: Header set ' + config.contentSecurityPolicyHeader + ' "..."'));
+        this.ui.writeLine(chalk.dim.cyan('# for Nginx : add_header ' + config.contentSecurityPolicyHeader + ' "...";') + '\n');
+      }
 
       var policyObject = config.contentSecurityPolicy;
       this.ui.writeLine(buildPolicyString(policyObject), 'ERROR');


### PR DESCRIPTION
1. Fixes #81. With a `--raw` option, the configuration guidelines are omitted.
2. Output to the standard output rather than to error. Maybe there's a good reason for sending it to error. In that case this change can be reverted. But otherwise, it seems semantically wrong to do that.
3. Add a small description for the `report-uri` option.