### PR TITLE
whitelist script tag inserted for test file loaded assertion using nonce

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,6 +100,8 @@ module.exports = {
     var options = config.options;
     var project = options.project;
 
+    console.log(options.environment);
+
     app.use(function(req, res, next) {
       var appConfig = project.config(options.environment);
 
@@ -111,6 +113,8 @@ module.exports = {
         return;
       }
 
+      // the local server will never run for production builds, so no danger in adding the nonce all the time
+      // even so it's only needed if tests are executed by opening `http://localhost:4200/tests`
       if (policyObject) {
         appendSourceList(policyObject, 'script-src', "'nonce-" + STATIC_TEST_NONCE + "'");
       }

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ var META_UNSUPPORTED_DIRECTIVES = [
   CSP_SANDBOX,
 ];
 
-var NONCE = 'abcdefg';
+var STATIC_TEST_NONCE = 'abcdefg';
 
 var unsupportedDirectives = function(policyObject) {
   return META_UNSUPPORTED_DIRECTIVES.filter(function(name) {
@@ -112,7 +112,7 @@ module.exports = {
       }
 
       if (policyObject) {
-        appendSourceList(policyObject, 'script-src', "'nonce-" + NONCE + "'");
+        appendSourceList(policyObject, 'script-src', "'nonce-" + STATIC_TEST_NONCE + "'");
       }
 
       // can be moved to the ember-cli-live-reload addon if RFC-22 is implemented
@@ -182,7 +182,7 @@ module.exports = {
       }
 
       if (policyObject && appConfig.environment === 'test') {
-        appendSourceList(policyObject, 'script-src', "'nonce-" + NONCE + "'");
+        appendSourceList(policyObject, 'script-src', "'nonce-" + STATIC_TEST_NONCE + "'");
       }
 
       var policyString = buildPolicyString(policyObject);
@@ -205,7 +205,7 @@ module.exports = {
       // Add nonce to <script> tag inserted by ember-cli to assert that test file was loaded.
       existingContent.forEach((entry, index) => {
         if (/<script>\s*Ember.assert\(.*EmberENV.TESTS_FILE_LOADED\);\s*<\/script>/.test(entry)) {
-          existingContent[index] = entry.replace('<script>', '<script nonce="' + NONCE + '">');
+          existingContent[index] = entry.replace('<script>', '<script nonce="' + STATIC_TEST_NONCE + '">');
         }
       });
     }


### PR DESCRIPTION
This adds a nonce to <script> tag inserted by ember-cli for assertion that test file was loaded. Otherwise this violates default CSP in tests.

Nonce is always present in CSP header but only part of CSP meta tag injected into `tests/index.html`.

A nonce used in productive applications must be cryptographically random. But since this one is only used in local development and if executing tests, using a static string is fine.