### PR TITLE
remove trailing whitespace from csp string

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -19,7 +19,7 @@ var buildPolicyString = function(policyObject) {
       var sourceList = Array.isArray(value) ? unique(value).join(' ') : value;
       return memo + name + ' ' + sourceList + '; ';
     }
-  }, '');
+  }, '').trim();
 };
 
 module.exports = { buildPolicyString: buildPolicyString };


### PR DESCRIPTION
CSP string generated and used in HTTP header, `<meta>` element and `ember csp-headers` command had a trailing whitespace. It's ugly and makes processing output of `ember csp-headers` more difficult in some cases.