### PR TITLE
Avoid merging policies in build time configuration

### DIFF
--- a/index.js
+++ b/index.js
@@ -271,16 +271,7 @@ function calculateConfig(environment, buildConfig, runConfig, ui) {
   }
 
   // apply configuration
-  // policy object is merged not replaced
-  if (buildConfig[CONFIG_KEY]) {
-    Object.keys(buildConfig[CONFIG_KEY]).forEach((key) => {
-      if (key === 'policy') {
-        Object.assign(config.policy, buildConfig[CONFIG_KEY].policy);
-      } else {
-        config[key] = buildConfig[CONFIG_KEY][key];
-      }
-    });
-  }
+  Object.assign(config, buildConfig[CONFIG_KEY]);
 
   return config;
 }

--- a/node-tests/unit/config-test.js
+++ b/node-tests/unit/config-test.js
@@ -25,12 +25,13 @@ describe('unit: configuration', function() {
     expect(config.reportOnly).to.be.true;
   });
 
-  it('merges policy object with default one', function() {
+  it('replaces default policy object with application config', function() {
     let config = calculateConfig(
       'development',
       {
         'ember-cli-content-security-policy': {
           policy: {
+            'default-src': ["'self'"],
             'font-src': ['examples.com']
           }
         }
@@ -39,13 +40,8 @@ describe('unit: configuration', function() {
       UIMock
     );
     expect(config.policy).to.deep.equal({
-      'default-src': ["'none'"],
-      'script-src':  ["'self'"],
+      'default-src': ["'self'"],
       'font-src':    ["examples.com"],
-      'connect-src': ["'self'"],
-      'img-src':     ["'self'"],
-      'style-src':   ["'self'"],
-      'media-src':   ["'self'"],
     });
   });
 


### PR DESCRIPTION
Should be backward-compatible as it still merges the policy object set by `contentSecurityPolicy` runtime config.

Closes #99 