### PR TITLE
fix livereload

### DIFF
--- a/node-tests/unit/config-test.js
+++ b/node-tests/unit/config-test.js
@@ -11,17 +11,17 @@ describe('unit: configuration', function() {
   });
 
   it('is enabled by default', function() {
-    let config = calculateConfig('development', {}, {}, {}, UIMock);
+    let config = calculateConfig('development', {}, {}, UIMock);
     expect(config.enabled).to.be.true;
   });
 
   it('delivers CSP by HTTP header by default', function() {
-    let config = calculateConfig('development', {}, {}, {}, UIMock);
+    let config = calculateConfig('development', {}, {}, UIMock);
     expect(config.delivery).to.deep.equal(['header']);
   });
 
   it('defaults to report only mode', function() {
-    let config = calculateConfig('development', {}, {}, {}, UIMock);
+    let config = calculateConfig('development', {}, {}, UIMock);
     expect(config.reportOnly).to.be.true;
   });
 
@@ -35,7 +35,6 @@ describe('unit: configuration', function() {
         }
       },
       {},
-      {},
       UIMock
     );
     expect(config.policy).to.deep.equal({
@@ -48,7 +47,6 @@ describe('unit: configuration', function() {
     it('supports `contentSecurityPolicy` config option', function() {
       let config = calculateConfig(
         'development',
-        {},
         {},
         {
           contentSecurityPolicy: {
@@ -73,7 +71,6 @@ describe('unit: configuration', function() {
       let config = calculateConfig(
         'development',
         {},
-        {},
         { contentSecurityPolicyMeta: true },
         UIMock
       );
@@ -81,7 +78,6 @@ describe('unit: configuration', function() {
 
       config = calculateConfig(
         'development',
-        {},
         {},
         { contentSecurityPolicyMeta: false },
         UIMock
@@ -93,7 +89,6 @@ describe('unit: configuration', function() {
       let config = calculateConfig(
         'development',
         {},
-        {},
         { contentSecurityPolicyHeader: 'Content-Security-Policy-Report-Only' },
         UIMock
       );
@@ -101,7 +96,6 @@ describe('unit: configuration', function() {
 
       config = calculateConfig(
         'development',
-        {},
         {},
         { contentSecurityPolicyHeader: 'Content-Security-Policy' },
         UIMock


### PR DESCRIPTION
Allowing connections and script source required by livereload feature was broken by configuration refactoring. This fixes it and adds tests.

This PR is based on #104. It should be merged afterwards.