### PR TITLE
Ensure `csp-headers` command emits to standard out (to allow for piping into other programs)

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -38,15 +38,14 @@ module.exports = {
         config.contentSecurityPolicy['report-uri'] = reportUri;
       }
 
-      if (!options.silent) {
-        this.ui.writeLine(chalk.dim.cyan('# Content Security Policy Header Configuration'));
-        this.ui.writeLine(chalk.dim.cyan('#'));
-        this.ui.writeLine(chalk.dim.cyan('# for Apache: Header set ' + config.contentSecurityPolicyHeader + ' "..."'));
-        this.ui.writeLine(chalk.dim.cyan('# for Nginx : add_header ' + config.contentSecurityPolicyHeader + ' "...";') + '\n');
-      }
+      this.ui.writeLine(chalk.dim.cyan('# Content Security Policy Header Configuration'));
+      this.ui.writeLine(chalk.dim.cyan('#'));
+      this.ui.writeLine(chalk.dim.cyan('# for Apache: Header set ' + config.contentSecurityPolicyHeader + ' "..."'));
+      this.ui.writeLine(chalk.dim.cyan('# for Nginx : add_header ' + config.contentSecurityPolicyHeader + ' "...";') + '\n');
 
       var policyObject = config.contentSecurityPolicy;
-      this.ui.writeLine(buildPolicyString(policyObject), 'ERROR');
+      // eslint-disable-next-line no-console
+      console.log(buildPolicyString(policyObject));
     }
   }
 };


### PR DESCRIPTION
1. `this.ui.writeLine` is automatically covering the `--silent` option. There is no need to wrap it up with the if.

2. The result should be always logged even in silent mode. There is no point to run this command without returning a header payload. That's why I used `console.log` as it logs always. Also, this will allow for saving the result to file eg: `ember csp-headers --silent > csp.txt` which can be later used during the deploy etc...