### PR TITLE
upgrade deprecation message for legacy configuration

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -93,7 +93,7 @@ function calculateConfig(environment, ownConfig, runConfig, ui) {
   ui.writeWarnLine(
     'Configuring ember-cli-content-security-policy using `contentSecurityPolicy`, ' +
     '`contentSecurityPolicyHeader` and `contentSecurityPolicyMeta` keys in `config/environment.js` ' +
-    'is deprecate and will be removed in v2.0.0. ember-cli-content-security-policy is now configured ' +
+    'is deprecate and will be removed in v3.0.0. ember-cli-content-security-policy is now configured ' +
     'using `ember-cli-build.js`. Please find detailed information about new configuration options ' +
     'in addon documentation at https://github.com/rwjblue/ember-cli-content-security-policy/blob/master/DEPRECATIONS.md.',
     !runConfig.contentSecurityPolicy || !runConfig.contentSecurityPolicyHeader || !runConfig.contentSecurityPolicyMeta


### PR DESCRIPTION
This upgrades the deprecation message for legacy configuration. As we now expect the release introducing that deprecation to be `v2`, we plan to remove it in `v3`. See #100 for details.