### PR TITLE
fix support for --live-reload-host option

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ module.exports = {
     // which are only available in `serverMiddleware` hook.
     if (options.liveReload) {
       this._liveReload = {
-        host: options.liveReloadHost,
+        hostname: options.liveReloadHost,
         port: options.liveReloadPort,
         ssl: options.ssl
       }


### PR DESCRIPTION
I think this was working in last release but broken by the refactoring done by myself.

Closes #18, #47 