### PR TITLE
Refactor logic related to building of policy string

### DIFF
--- a/index.js
+++ b/index.js
@@ -184,6 +184,8 @@ module.exports = {
   // hook to support live reload. This is safe because `serverMiddleware` hook is executed
   // before `contentFor` hook.
   included: function(app) {
+    this._super.included.apply(this, arguments);
+
     let environment = app.env;
     let ownConfig = readConfig(app.project, environment);  // config/content-security-policy.js
     let runConfig = app.project.config(); // config/environment.js

--- a/index.js
+++ b/index.js
@@ -50,66 +50,61 @@ module.exports = {
   name: require('./package').name,
 
   serverMiddleware: function({ app, options }) {
-    // Calculate livereload settings and cache it to be reused in `contentFor` hook.
-    // Can't do that one in another hook cause it depends on middleware options,
-    // which are only available in `serverMiddleware` hook.
+    // Configuration is not changeable at run-time. Therefore it's safe to not
+    // register the express middleware at all if addon is disabled and
+    // precalculate dynamic values.
+    if (!this._config.enabled) {
+      return;
+    }
+
+    // Need to recalculate the policy if local development server is used to
+    // support live reload, executing tests in development enviroment via
+    // `http://localhost:4200/tests` and reporting CSP violations on CLI.
+    let policyObject = this._config.policy;
+
+    // the local server will never run for production builds, so no danger in
+    // adding the nonce all the time even so it's only needed if tests are
+    // executed by opening `http://localhost:4200/tests`
+    appendSourceList(policyObject, 'script-src', "'nonce-" + STATIC_TEST_NONCE + "'");
+
+    // live reload requires some addition CSP directives
     if (options.liveReload) {
-      this._liveReload = {
+      allowLiveReload(policyObject, {
         hostname: options.liveReloadHost,
         port: options.liveReloadPort,
         ssl: options.ssl
-      }
+      });
     }
 
+    // add report URI to policy object and allow it as connection source
+    if (this._config.reportOnly && !('report-uri' in policyObject)) {
+      let ecHost = options.host || 'localhost';
+      let ecProtocol = options.ssl ? 'https://' : 'http://';
+      let ecOrigin = ecProtocol + ecHost + ':' + options.port;
+      appendSourceList(policyObject, 'connect-src', ecOrigin);
+      policyObject['report-uri'] = ecOrigin + REPORT_PATH;
+    }
+
+    this._policyString = buildPolicyString(policyObject);
+
     app.use((req, res, next) => {
-      if (!this._config.enabled) {
-        next();
-        return;
-      }
-
       let header = this._config.reportOnly ? CSP_HEADER_REPORT_ONLY : CSP_HEADER;
-      // clone policy object cause config should not be mutated
-      let policyObject = Object.assign({}, this._config.policy);
-
-      // the local server will never run for production builds, so no danger in adding the nonce all the time
-      // even so it's only needed if tests are executed by opening `http://localhost:4200/tests`
-      if (policyObject) {
-        appendSourceList(policyObject, 'script-src', "'nonce-" + STATIC_TEST_NONCE + "'");
-      }
-
-      if (this._liveReload) {
-        allowLiveReload(policyObject, this._liveReload);
-      }
-
-      // only needed for headers, since report-uri cannot be specified in meta tag
-      if (header.indexOf('Report-Only') !== -1 && !('report-uri' in policyObject)) {
-        let ecHost = options.host || 'localhost';
-        let ecProtocol = options.ssl ? 'https://' : 'http://';
-        let ecOrigin = ecProtocol + ecHost + ':' + options.port;
-        appendSourceList(policyObject, 'connect-src', ecOrigin);
-        policyObject['report-uri'] = ecOrigin + REPORT_PATH;
-      }
-
-      let headerValue = buildPolicyString(policyObject);
-
-      if (!headerValue) {
-        next();
-        return;
-      }
+      let policyString = this._policyString;
 
       // clear existing headers before setting ours
       res.removeHeader(CSP_HEADER);
       res.removeHeader(CSP_HEADER_REPORT_ONLY);
-      res.setHeader(header, headerValue);
+      res.setHeader(header, policyString);
 
       // for Internet Explorer 11 and below (Edge support the standard header name)
       res.removeHeader('X-' + CSP_HEADER);
       res.removeHeader('X-' + CSP_HEADER_REPORT_ONLY);
-      res.setHeader('X-' + header, headerValue);
+      res.setHeader('X-' + header, policyString);
 
       next();
     });
 
+    // register handler for CSP reports
     let bodyParser = require('body-parser');
     app.use(REPORT_PATH, bodyParser.json({ type: 'application/csp-report' }));
     app.use(REPORT_PATH, bodyParser.json({ type: 'application/json' }));
@@ -133,31 +128,13 @@ module.exports = {
         this._config.reportOnly
       );
 
-      let policyObject = Object.assign({}, this._config.policy);
-
-      if (policyObject && appConfig.environment === 'test') {
-        appendSourceList(policyObject, 'script-src', "'nonce-" + STATIC_TEST_NONCE + "'");
-      }
-
-      if (this._liveReload) {
-        allowLiveReload(policyObject, this._liveReload);
-      }
-
-      // clone policy object cause config should not be mutated
-      let policyString = buildPolicyString(policyObject);
-
-      unsupportedDirectives(policyObject).forEach(function(name) {
+      unsupportedDirectives(this._config.policy).forEach(function(name) {
         let msg = 'CSP delivered via meta does not support `' + name + '`, ' +
                   'per the W3C recommendation.';
         console.log(chalk.yellow(msg)); // eslint-disable-line no-console
       });
 
-      if (!policyString) {
-        // eslint-disable-next-line no-console
-        console.log(chalk.yellow('CSP via meta tag enabled but no policy exist.'));
-      } else {
-        return '<meta http-equiv="' + CSP_HEADER + '" content="' + policyString + '">';
-      }
+      return `<meta http-equiv="${CSP_HEADER}" content="${this._policyString}">`;
     }
 
     if (type === 'test-body' && this._config.failTests) {
@@ -206,19 +183,31 @@ module.exports = {
   // that one is executed after `serverMiddleware` and can't do it in `serverMiddleware`
   // hook cause that one is only executed on `ember serve` but not on `ember build` or
   // `ember test`. We can't do it in `init` hook cause app is not available by then.
+  //
+  // The same applies to policy string generation. It's also calculated in `included`
+  // hook and reused in both others. But this one might be overriden in `serverMiddleware`
+  // hook to support live reload. This is safe because `serverMiddleware` hook is executed
+  // before `contentFor` hook.
   included: function(app) {
     let environment = app.env;
     let ownConfig = readConfig(app.project, environment);  // config/content-security-policy.js
     let runConfig = app.project.config(); // config/environment.js
     let ui = app.project.ui;
+    let config = calculateConfig(environment, ownConfig, runConfig, ui);
 
-    this._config = calculateConfig(environment, ownConfig, runConfig, ui);
+    // add static test nonce in test environment
+    if (environment === 'test') {
+      appendSourceList(config.policy, 'script-src', `'nonce-${STATIC_TEST_NONCE}'`);
+    }
+
+    this._config = config;
+    this._policyString = buildPolicyString(config.policy);
   },
 
   // holds configuration for this addon
   _config: null,
 
-  // holds live reload configuration if express server is used and live reload is enabled
-  _liveReload: null,
+  // holds calculated policy string
+  _policyString: null,
 };
 

--- a/index.js
+++ b/index.js
@@ -62,11 +62,6 @@ module.exports = {
     // `http://localhost:4200/tests` and reporting CSP violations on CLI.
     let policyObject = this._config.policy;
 
-    // the local server will never run for production builds, so no danger in
-    // adding the nonce all the time even so it's only needed if tests are
-    // executed by opening `http://localhost:4200/tests`
-    appendSourceList(policyObject, 'script-src', "'nonce-" + STATIC_TEST_NONCE + "'");
-
     // live reload requires some addition CSP directives
     if (options.liveReload) {
       allowLiveReload(policyObject, {
@@ -195,8 +190,8 @@ module.exports = {
     let ui = app.project.ui;
     let config = calculateConfig(environment, ownConfig, runConfig, ui);
 
-    // add static test nonce in test environment
-    if (environment === 'test') {
+    // add static test nonce if build includes tests
+    if (app.tests) {
       appendSourceList(config.policy, 'script-src', `'nonce-${STATIC_TEST_NONCE}'`);
     }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -125,7 +125,52 @@ function calculateConfig(environment, ownConfig, runConfig, ui) {
   return config;
 }
 
+/**
+ * Appends additional directives to an existing policy object.
+ * It mutates the existing policy object and it's directive values.
+ *
+ * If the directive is not defined yet, it's initalized with a copy
+ * of default-src directive. This is required to not break the built-in
+ * fallback mechanism of CSP.
+ *
+ * If, say, `connect-src` is not defined it will fall back to `default-src`.
+ * This can cause issues if not respected when extending a given policy
+ * object. An example:
+ *
+ * Developer has has defined the following policy:
+ * `default-src: 'self' example.com;`
+ * and an addon appends the connect-src entry live-reload.local the result is:
+ * `default-src: 'self' example.com; connect-src: live-reload.local;`
+ *
+ * After the addons change an xhr to example.com (which was previously permitted,
+ *  via fallback) will now be rejected since it doesn't match live-reload.local.
+ *
+ * To mitigate, whenever we append to a non-existing directive we must also copy
+ * all sources from default-src onto the specified directive.
+ *
+ * @param {object} policyObject
+ * @param {string} directiveName
+ * @param {string} sourceList
+ * @return {void}
+ */
+function appendSourceList(policyObject, directiveName, sourceList) {
+  let value = policyObject[directiveName];
+
+  if (!Array.isArray(value) && value !== undefined && value !== null) {
+    // null is only supported for legacy reasons
+    throw new Error(`Source list must be an array or undefined, ${value} given.`);
+  }
+
+  if (!Array.isArray(value)) {
+    // initialize source list with an copy of default-src (see above)
+    policyObject[directiveName] = policyObject['default-src'] ? policyObject['default-src'].slice() : [];
+  }
+
+  policyObject[directiveName].push(sourceList);
+}
+
 module.exports = {
+  appendSourceList,
   buildPolicyString,
   calculateConfig,
   readConfig

--- a/node-tests/e2e/deliver-test.js
+++ b/node-tests/e2e/deliver-test.js
@@ -103,6 +103,31 @@ describe('e2e: delivers CSP as configured', function() {
       await app.stopServer();
     });
 
+    it('does not deliver CSP through HTTP header if delivery does not include "header"', async function() {
+      await setConfig(app, {
+        delivery: ['meta'],
+      });
+
+      await app.startServer();
+
+      let response = await request({
+        url: 'http://localhost:49741',
+        headers: {
+          'Accept': 'text/html'
+        }
+      });
+
+      expect(response.headers).to.not.have.key('content-security-policy-report-only');
+      expect(response.headers).to.not.have.key('content-security-policy');
+      expect(response.body).to.match(CSP_META_TAG_REG_EXP);
+    });
+  });
+
+  describe('', function() {
+    afterEach(async function() {
+      await app.stopServer();
+    });
+
     it('does not deliver CSP if `enabled` option is `false`', async function() {
       await setConfig(app, {
         enabled: false,

--- a/node-tests/unit/append-source-list-test.js
+++ b/node-tests/unit/append-source-list-test.js
@@ -1,0 +1,30 @@
+const expect = require('chai').expect;
+const { appendSourceList } = require('../../lib/utils');
+
+describe('unit: appendSourceList', function() {
+  it('appends to existing directive', function() {
+    let sourceList = {
+      'default-src': ["'none'"],
+      'script-src': ["'self'"],
+    };
+
+    appendSourceList(sourceList, 'script-src', 'examples.com');
+    expect(sourceList).to.have.all.keys('default-src', 'script-src');
+    expect(sourceList['script-src']).to.be.an('array');
+    expect(sourceList['script-src']).to.contain("'self'");
+    expect(sourceList['script-src']).to.contain('examples.com');
+  });
+
+  it('initalizes a not yet defined directive with default-src', function() {
+    let sourceList = {
+      'default-src': ["'self'"]
+    };
+
+    appendSourceList(sourceList, 'script-src', 'examples.com');
+    expect(sourceList).to.have.all.keys('default-src', 'script-src');
+    expect(sourceList['script-src']).to.be.an('array');
+    expect(sourceList['script-src']).to.contain("'self'");
+    expect(sourceList['script-src']).to.contain('examples.com');
+    expect(sourceList['default-src']).to.deep.equal(["'self'"]);
+  });
+});


### PR DESCRIPTION
- Policy object values should not be converted to strings.
- Policy string should be calculated once and reused.
- Fixes a bug that CSP is delivered through header even if `delivery` does not include `"header"`.
- Improves readability of tests.