### PR TITLE
inject instance initializer only if required

### DIFF
--- a/fastboot/instance-initializers/content-security-policy.js
+++ b/fastboot/instance-initializers/content-security-policy.js
@@ -9,7 +9,7 @@ function readAddonConfig(appInstance) {
   //       if already available through CSP meta element
   assert(
     'Required configuration is available at run-time',
-    addonConfig.hasOwnProperty('reportOnly') && addonConfig.hasOwnProperty('policy')
+    addonConfig && addonConfig.hasOwnProperty('reportOnly') && addonConfig.hasOwnProperty('policy')
   );
 
   return config['ember-cli-content-security-policy'];

--- a/node-tests/e2e/deliver-test.js
+++ b/node-tests/e2e/deliver-test.js
@@ -20,7 +20,7 @@ describe('e2e: delivers CSP as configured', function() {
     await app.create('default', { noFixtures: true });
   });
 
-  describe('delivery through meta element', function() {
+  describe('scenario: delivery through meta element', function() {
     before(async function() {
       await setConfig(app, {
         delivery: ['header', 'meta'],
@@ -63,7 +63,7 @@ describe('e2e: delivers CSP as configured', function() {
     });
   });
 
-  describe('report only', function() {
+  describe('scenario: report only', function() {
     before(async function() {
       await setConfig(app, {
         delivery: ['header'],
@@ -91,7 +91,7 @@ describe('e2e: delivers CSP as configured', function() {
     });
   });
 
-  describe('delivery through meta only', function() {
+  describe('scenario: delivery through meta only', function() {
     before(async function() {
       await setConfig(app, {
         delivery: ['meta'],
@@ -119,7 +119,7 @@ describe('e2e: delivers CSP as configured', function() {
     });
   });
 
-  describe('disabled', function() {
+  describe('scenario: disabled', function() {
     before(async function() {
       await setConfig(app, {
         enabled: false,
@@ -147,7 +147,7 @@ describe('e2e: delivers CSP as configured', function() {
     });
   });
 
-  describe('supports live reload', function() {
+  describe('feature: live reload support', function() {
     before(async function() {
       await setConfig(app, {
         delivery: ['header', 'meta'],


### PR DESCRIPTION
Removes `fastboot/instance-initializers/content-security-policy.js` from tree if CSP headers should not be set by FastBoot. This prevents unnecessary code in build output. As the same scenarios are used as for not injecting the run-time configuration it fixes #117 also.

It also increases the test coverage. Especially it ensures that there wasn't an error thrown at FastBoot render and verifies that run-time configuration is not part of the build.