### PR TITLE
inject runtime config only if FastBoot dependency exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,9 +88,7 @@ module.exports = {
     // - application has ember-cli-fastboot dependency.
     this._needsFastBootSupport = this._config.enabled &&
       this._config.delivery.includes('header') &&
-      // TODO: check if application has ember-cli-fastboot-dependency
-      // https://github.com/rwjblue/ember-cli-content-security-policy/issues/116
-      true;
+      new VersionChecker(this).for('ember-cli-fastboot').exists();
 
     // Run-time configuration is only needed for FastBoot support.
     if (!this._needsFastBootSupport) {

--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ module.exports = {
     // - application has ember-cli-fastboot dependency.
     this._needsFastBootSupport = this._config.enabled &&
       this._config.delivery.includes('header') &&
-      new VersionChecker(this).for('ember-cli-fastboot').exists();
+      new VersionChecker(this.project).for('ember-cli-fastboot').exists();
 
     // Run-time configuration is only needed for FastBoot support.
     if (!this._needsFastBootSupport) {
@@ -250,4 +250,3 @@ module.exports = {
   // holds calculated policy string
   _policyString: null,
 };
-

--- a/node-tests/e2e/fastboot-support-app-not-using-fastboot-test.js
+++ b/node-tests/e2e/fastboot-support-app-not-using-fastboot-test.js
@@ -8,8 +8,7 @@ function getRunTimeConfig(html) {
   return JSON.parse(decodeURIComponent(encodedConfig));
 }
 
-// ember-cli-version-checker reports wrong information if used together with ember-cli-addon-tests.
-describe.skip('e2e: fastboot integration if consumer does not use FastBoot', function() {
+describe('e2e: fastboot integration if consumer does not use FastBoot', function() {
   this.timeout(300000);
 
   let app;

--- a/node-tests/e2e/fastboot-support-app-not-using-fastboot-test.js
+++ b/node-tests/e2e/fastboot-support-app-not-using-fastboot-test.js
@@ -1,0 +1,52 @@
+const expect = require('chai').expect;
+const AddonTestApp = require('ember-cli-addon-tests').AddonTestApp;
+const denodeify = require('denodeify');
+const request = denodeify(require('request'));
+
+function getRunTimeConfig(html) {
+  let encodedConfig = html.match(/<meta name="default\/config\/environment" content="(.*)" \/>/)[1];
+  return JSON.parse(decodeURIComponent(encodedConfig));
+}
+
+// ember-cli-version-checker reports wrong information if used together with ember-cli-addon-tests.
+describe.skip('e2e: fastboot integration if consumer does not use FastBoot', function() {
+  this.timeout(300000);
+
+  let app;
+
+  before(async function() {
+    app = new AddonTestApp();
+
+    await app.create('default', {
+      noFixtures: true,
+      skipNpm: true,
+    });
+
+    await app.editPackageJSON(pkg => {
+      delete pkg.devDependencies['ember-cli-fastboot'];
+      delete pkg.devDependencies['fastboot-app-server'];
+    });
+
+    await app.run('npm', 'install');
+
+    await app.startServer();
+  });
+
+  after(async function() {
+    await app.stopServer();
+  });
+
+  it('does not push run-time configuration into app if app does not use FastBoot', async function() {
+    let response = await request({
+      url: 'http://localhost:49741',
+      headers: {
+        'Accept': 'text/html'
+      }
+    });
+
+    expect(response.statusCode).to.equal(200);
+
+    let runTimeConfig = getRunTimeConfig(response.body);
+    expect(runTimeConfig).to.not.include.key('ember-cli-content-security-policy');
+  });
+});


### PR DESCRIPTION
Ensures that runtime configuration is not injected if it's not needed cause consuming app does not have a dependency on FastBoot.

Have verified manually that it's working by using this feature branch in a new app. `ember-cli-version-checker` seems to report wrong information if used with `yarn link` and `ember-cli-content-security-policy`, which makes testing this one difficult and may cause confusion. Symlinking the addon may be causing the issue in both cases. Need to investigate a little bit more and report their.

It also sounds similar to https://github.com/ember-cli/ember-cli-version-checker/issues/93. There the issue was traced down that some dependencies was causing an old version of ember-cli-version-checker to be used. Need to investigate if that one cause the issues here as well. But will do separately. Please feel free to merge this one with the skipped test.

Closes #116 