### PR TITLE
Don't add nonce to script-src when it already contains 'unsafe-inline'

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,8 +83,13 @@ module.exports = {
         let runConfigForTest = project.config('test');
         let configForTest = calculateConfig('test', ownConfigForTest, runConfigForTest, ui);
 
-        // add static nonce required for tests
-        appendSourceList(configForTest.policy, 'script-src', `'nonce-${STATIC_TEST_NONCE}'`);
+        // add static nonce required for tests, but only if if script-src
+        // does not contain 'unsafe-inline'. if a nonce is present, browsers
+        // ignore the 'unsafe-inline' directive.
+        let scriptSrc = configForTest.policy['script-src'];
+        if (!(scriptSrc && scriptSrc.includes("'unsafe-inline'"))) {
+          appendSourceList(configForTest.policy, 'script-src', `'nonce-${STATIC_TEST_NONCE}'`);
+        }
 
         // testem requires frame-src to run
         configForTest.policy['frame-src'] = ["'self'"];


### PR DESCRIPTION
Fixes #127.

I added a test for both the positive (should add nonce) and negative (should not add nonce) case, because I could not find a test for the former and I wanted to make sure I didn't accidentally break that scenario.