### PR TITLE
Set status-code to 204 (no content)

### DIFF
--- a/index.js
+++ b/index.js
@@ -194,7 +194,8 @@ module.exports = {
     app.use(REPORT_PATH, function(req, res, _next) {
       // eslint-disable-next-line no-console
       console.log(chalk.red('Content Security Policy violation:') + '\n\n' + JSON.stringify(req.body, null, 2));
-      res.send({ status:'ok' });
+      // send empty ok response, to avoid Cross-Origin Resource Blocking (CORB) warning
+      res.status(204).send();
     });
   },
 


### PR DESCRIPTION
With Cross-Origin Read Blocking (CORB), the JSON response we've used to send as a reply to the CSP-report `{"status":"ok"}`, is hit with CORB blocking.

While this warning is harmless (because the client doesn't care about the response to the CSP report), we want to avoid the warning that is shown in Chrome, and possibly other browsers.

By not sending any response body, we avoid triggering CORB-blocking. The spec doesn't expect any response to CSP-report POSTs, so changing to 204 and an empty body is safe + status-code should still be enough to signify that the response was received.

The Chrome console warning looks like this:

> Cross-Origin Read Blocking (CORB) blocked cross-origin response http://127.0.0.1:5530/csp-report with MIME type application/json.

More details:
https://chromium.googlesource.com/chromium/src/+/master/services/network/cross_origin_read_blocking_explainer.md#Determining-whether-a-response-is-CORB_protected

*Sadly I committed this directly to master first (I pressed the wrong button!), but have reverted that commit. Sorry for that!*