### PR TITLE
Drop Node 8, 9, and 11 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "8"
+  - "10"
 
 sudo: false
 dist: trusty

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "request": "^2.88.0"
   },
   "engines": {
-    "node": "8.* || >= 10.*"
+    "node": "10.* || >= 12.*"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
All of these Node versions are already unsupported by Node itself, it seems good to drop support prior to the next major release.