### PR TITLE
do not set X-Content-Security-Policy header

### DIFF
--- a/index.js
+++ b/index.js
@@ -172,12 +172,9 @@ module.exports = {
       // clear existing headers before setting ours
       res.removeHeader(CSP_HEADER);
       res.removeHeader(CSP_HEADER_REPORT_ONLY);
-      res.setHeader(header, policyString);
 
-      // for Internet Explorer 11 and below (Edge support the standard header name)
-      res.removeHeader('X-' + CSP_HEADER);
-      res.removeHeader('X-' + CSP_HEADER_REPORT_ONLY);
-      res.setHeader('X-' + header, policyString);
+      // set csp header
+      res.setHeader(header, policyString);
 
       next();
     });


### PR DESCRIPTION
All major browsers support Content-Security-Policy header since a long time. Only Internet Explorer 11 does not support it. But it also only supports `sandbox` directive by X-Content-Security-Policy header. The sandbox is not useful at all for Ember applications cause it could only be used to disable all scripts. As an Ember applicaiton is not usable at all without JavaScript that is not a reasonable configuration.

This resolves the inconsistency between middleware used in Ember CLI's development server and FastBoot initalizier described in #133.