### PR TITLE
append frame-src config in test mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -363,7 +363,7 @@ module.exports = {
       }
 
       // testem requires frame-src to run
-      config.policy['frame-src'] = ["'self'"];
+      appendSourceList(config.policy, 'frame-src', "'self'");
 
       // enforce delivery through meta
       config.delivery.push('meta');


### PR DESCRIPTION
Addresses https://github.com/rwjblue/ember-cli-content-security-policy/issues/151

Note this works in my case because my app has `frame-src` defined. From the failing tests it appears `appendSourceList` does not handle the case of a missing `frame-src` properly. Should `appendSourceList` get smarter or should this problem get solved via another approach?