### PR TITLE
refactor tests to use Ember Addon Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ node_js:
   # so that your addon works for all apps
   - "10"
 
-sudo: false
-dist: trusty
+dist: xenial
 
 addons:
   chrome: stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,8 @@ jobs:
       env: EMBER_CLI_VERSION=~3.4.0
     - env: EMBER_CLI_VERSION=~3.8.0
     - env: EMBER_CLI_VERSION=~3.12.0
+    - env: EMBER_CLI_VERSION=~3.16.0
+    - env: EMBER_CLI_VERSION=~3.20.0
     - env: EMBER_CLI_VERSION=latest
     - env: EMBER_CLI_VERSION=beta
 

--- a/index.js
+++ b/index.js
@@ -105,7 +105,7 @@ module.exports = {
     // - application has ember-cli-fastboot dependency.
     this._needsFastBootSupport = this._config.enabled &&
       this._config.delivery.includes('header') &&
-      new VersionChecker(this.project).for('ember-cli-fastboot').exists();
+      this.project.findAddonByName('ember-cli-fastboot') !== null;
 
     // Run-time configuration is only needed for FastBoot support.
     if (!this._needsFastBootSupport) {

--- a/node-tests/e2e/cli-command-test.js
+++ b/node-tests/e2e/cli-command-test.js
@@ -1,34 +1,38 @@
 const expect = require('chai').expect;
-const AddonTestApp = require('ember-cli-addon-tests').AddonTestApp;
+const TestProject = require('ember-addon-tests').default;
 const {
   removeConfig,
   setConfig
 } = require('../utils');
+const path = require('path');
 
 describe('e2e: CLI command csp-headers', function() {
   this.timeout(300000);
 
-  let app;
+  let testProject;
 
   before(async function() {
-    app = new AddonTestApp();
+    testProject = new TestProject({
+      projectRoot: path.join(__dirname, '../..')
+    });
 
-    await app.create('default', { noFixtures: true });
+    await testProject.createEmberApp();
+    await testProject.addOwnPackageAsDevDependency('ember-cli-content-security-policy');
   });
 
   afterEach(async function() {
-    await removeConfig(app);
+    await removeConfig(testProject);
   });
 
   it('returns CSP on stdout', async function() {
-    await setConfig(app, {
+    await setConfig(testProject, {
       policy: {
         'default-src': "'self'",
         'script-src': "'self' 'unsafe-inline'",
       },
     });
 
-    let { output } = await app.runEmberCommand('csp-headers', '--silent');
-    expect(output[0]).to.equal("default-src 'self'; script-src 'self' 'unsafe-inline';\n");
+    let { stdout } = await testProject.runEmberCommand('csp-headers', '--silent');
+    expect(stdout).to.equal("default-src 'self'; script-src 'self' 'unsafe-inline';");
   });
 });

--- a/node-tests/e2e/test-support-test.js
+++ b/node-tests/e2e/test-support-test.js
@@ -28,7 +28,12 @@ describe('e2e: provides test support', function() {
     // of our custom test support.
     // To avoid this issue we uninstall Ember Auto Import for these tests. This can be removed
     // as soon as Ember CLI Content Security Policy works out of the box with Ember Auto Import.
-    await testProject.runCommand('yarn', 'remove', 'ember-auto-import');
+    try {
+      await testProject.runCommand('yarn', 'remove', 'ember-auto-import');
+    } catch(error) {
+      // Trying to remove ember-auto-import dependency may fail cause that dependency is not
+      // present for older Ember CLI versions.
+    }
 
     await testProject.addOwnPackageAsDevDependency('ember-cli-content-security-policy');
 

--- a/node-tests/e2e/test-support-warns-on-outdated-qunit-test.js
+++ b/node-tests/e2e/test-support-warns-on-outdated-qunit-test.js
@@ -20,10 +20,7 @@ describe('e2e: test support warns if dependencies are not supported', function()
 
       // expect runEmberCommand to throw
       expect(false).to.be.true;
-    } catch ({ stdout, stderr }) {
-      console.log(stderr);
-      console.log(await testProject.readFile('package.json'));
-      console.log(await testProject.runCommand('yarn', 'why', 'ember-qunit'));
+    } catch ({ stdout }) {
       expect(stdout).to.include('WARNING: QUnit < 2.9.2 violates a strict Content Security Policy (CSP) by itself.');
     }
   });

--- a/node-tests/e2e/test-support-warns-on-outdated-qunit-test.js
+++ b/node-tests/e2e/test-support-warns-on-outdated-qunit-test.js
@@ -20,8 +20,9 @@ describe('e2e: test support warns if dependencies are not supported', function()
 
       // expect runEmberCommand to throw
       expect(false).to.be.true;
-    } catch ({ stdout }) {
-      expect(stdout).to.include('WARNING: QUnit < 2.9.2 violates a strict Content Security Policy (CSP) by itself.');
+    } catch (error) {
+      console.log(error);
+      expect(error.stdout).to.include('WARNING: QUnit < 2.9.2 violates a strict Content Security Policy (CSP) by itself.');
     }
   });
 });

--- a/node-tests/e2e/test-support-warns-on-outdated-qunit-test.js
+++ b/node-tests/e2e/test-support-warns-on-outdated-qunit-test.js
@@ -20,9 +20,11 @@ describe('e2e: test support warns if dependencies are not supported', function()
 
       // expect runEmberCommand to throw
       expect(false).to.be.true;
-    } catch (error) {
-      console.log(error);
-      expect(error.stdout).to.include('WARNING: QUnit < 2.9.2 violates a strict Content Security Policy (CSP) by itself.');
+    } catch ({ stdout, stderr }) {
+      console.log(stderr);
+      console.log(await testProject.readFile('package.json'));
+      console.log(await testProject.runCommand('yarn', 'why', 'ember-qunit'));
+      expect(stdout).to.include('WARNING: QUnit < 2.9.2 violates a strict Content Security Policy (CSP) by itself.');
     }
   });
 });

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "start": "ember serve",
     "test": "ember test",
     "test:all": "ember try:each",
-    "test:node": "for i in node-tests/*/*; do mocha $i; done"
+    "test:node": "mocha node-tests/**/*-test.js"
   },
   "dependencies": {
     "body-parser": "^1.17.0",
@@ -34,6 +34,7 @@
     "broccoli-asset-rev": "^3.0.0",
     "chai": "^4.2.0",
     "denodeify": "^1.2.1",
+    "ember-addon-tests": "^0.0.1",
     "ember-cli": "~3.16.1",
     "ember-cli-addon-tests": "^0.11.1",
     "ember-cli-dependency-checker": "^3.2.0",
@@ -55,6 +56,7 @@
     "ember-try": "^1.4.0",
     "eslint-plugin-ember": "^8.1.1",
     "eslint-plugin-node": "^11.0.0",
+    "execa": "^4.1.0",
     "fs-extra": "^9.0.0",
     "loader.js": "^4.7.0",
     "mocha": "^7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1201,7 +1201,20 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
-"@types/node@*", "@types/node@>= 8":
+"@types/node-fetch@^2.5.7":
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.7.tgz#20a2afffa882ab04d44ca786449a276f9f6bbf3c"
+  integrity sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==
+  dependencies:
+    "@types/node" "*"
+    form-data "^3.0.0"
+
+"@types/node@*":
+  version "14.11.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.11.2.tgz#2de1ed6670439387da1c9f549a2ade2b0a799256"
+  integrity sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA==
+
+"@types/node@>= 8":
   version "13.11.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.11.1.tgz#49a2a83df9d26daacead30d0ccc8762b128d53c7"
   integrity sha512-eWQGP3qtxwL8FGneRrC5DwrJLGN4/dH1clNTuLfN81HCrxVtxRjygDTUoZJ5ASlDEeo0ppYFQjQIlXhtXpOn6g==
@@ -3701,6 +3714,11 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
+copy-dir@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/copy-dir/-/copy-dir-1.3.0.tgz#8c65130e11d8313a6ac2c0578e4c6c6f70b456ba"
+  integrity sha512-Q4+qBFnN4bwGwvtXXzbp4P/4iNk0MaiGAzvQ8OiMtlLjkIKjmNN689uVzShSM0908q7GoFHXIPx4zi75ocoaHw==
+
 core-js-compat@^3.6.2:
   version "3.6.5"
   resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.6.5.tgz#2a51d9a4e25dfd6e690251aa81f99e3c05481f1c"
@@ -3756,9 +3774,9 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     which "^1.2.9"
 
 cross-spawn@^7.0.0:
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.2.tgz#d0d7dcfa74e89115c7619f4f721a94e1fdb716d6"
-  integrity sha512-PD6G8QG3S4FK/XCGFbEQrDqO2AnMMsy0meR7lerlIOHAAbkuavGU/pOqprrlvfTNjvowivTeBsjebAL0NSoMxw==
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
+  integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
   dependencies:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
@@ -3795,12 +3813,19 @@ debug@3.2.6, debug@^3.0.0, debug@^3.0.1, debug@^3.1.0, debug@^3.1.1:
   dependencies:
     ms "^2.1.1"
 
-debug@4, debug@4.1.1, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@~4.1.0:
+debug@4, debug@4.1.1, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@~4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
+
+debug@^4.1.1:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.2.0.tgz#7f150f93920e94c58f5574c2fd01a3110effe7f1"
+  integrity sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==
+  dependencies:
+    ms "2.1.2"
 
 debug@~3.1.0:
   version "3.1.0"
@@ -4042,6 +4067,19 @@ electron-to-chromium@^1.3.390, electron-to-chromium@^1.3.47:
   version "1.3.403"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.403.tgz#c8bab4e2e72bf78bc28bad1cc355c061f9cc1918"
   integrity sha512-JaoxV4RzdBAZOnsF4dAlZ2ijJW72MbqO5lNfOBHUWiBQl3Rwe+mk2RCUMrRI3rSClLJ8HSNQNqcry12H+0ZjFw==
+
+ember-addon-tests@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/ember-addon-tests/-/ember-addon-tests-0.0.1.tgz#c190be51c8ea619b796131b93980451d16f0ba62"
+  integrity sha512-C5neD9mLPPBnuPlmuRS9VwJuyT6FdNQFubmqFghDv8IeDMVNnlaRuYcNHInJLCKg/oshNZnkVcqrHFyTatkatA==
+  dependencies:
+    "@types/node-fetch" "^2.5.7"
+    copy-dir "^1.3.0"
+    debug "^4.1.1"
+    execa "^4.0.3"
+    fs-extra "^9.0.1"
+    lodash "^4.17.20"
+    rimraf "^3.0.2"
 
 ember-assign-polyfill@^2.6.0:
   version "2.6.0"
@@ -4968,6 +5006,36 @@ execa@^1.0.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+execa@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-4.0.3.tgz#0a34dabbad6d66100bd6f2c576c8669403f317f2"
+  integrity sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==
+  dependencies:
+    cross-spawn "^7.0.0"
+    get-stream "^5.0.0"
+    human-signals "^1.1.1"
+    is-stream "^2.0.0"
+    merge-stream "^2.0.0"
+    npm-run-path "^4.0.0"
+    onetime "^5.1.0"
+    signal-exit "^3.0.2"
+    strip-final-newline "^2.0.0"
+
+execa@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-4.1.0.tgz#4e5491ad1572f2f17a77d388c6c857135b22847a"
+  integrity sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==
+  dependencies:
+    cross-spawn "^7.0.0"
+    get-stream "^5.0.0"
+    human-signals "^1.1.1"
+    is-stream "^2.0.0"
+    merge-stream "^2.0.0"
+    npm-run-path "^4.0.0"
+    onetime "^5.1.0"
+    signal-exit "^3.0.2"
+    strip-final-newline "^2.0.0"
+
 exists-sync@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/exists-sync/-/exists-sync-0.0.4.tgz#9744c2c428cc03b01060db454d4b12f0ef3c8879"
@@ -5393,7 +5461,7 @@ forever-agent@~0.6.1:
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
 
-form-data@3.0.0:
+form-data@3.0.0, form-data@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.0.tgz#31b7e39c85f1355b7139ee0c647cf0de7f83c682"
   integrity sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==
@@ -5486,6 +5554,16 @@ fs-extra@^9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.0.0.tgz#b6afc31036e247b2466dc99c29ae797d5d4580a3"
   integrity sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==
+  dependencies:
+    at-least-node "^1.0.0"
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^1.0.0"
+
+fs-extra@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.0.1.tgz#910da0062437ba4c39fedd863f1675ccfefcb9fc"
+  integrity sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==
   dependencies:
     at-least-node "^1.0.0"
     graceful-fs "^4.2.0"
@@ -5619,7 +5697,14 @@ get-stream@^4.0.0, get-stream@^4.1.0:
   dependencies:
     pump "^3.0.0"
 
-get-stream@^5.0.0, get-stream@^5.1.0:
+get-stream@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-5.2.0.tgz#4966a1795ee5ace65e706c4b7beb71257d6e22d3"
+  integrity sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==
+  dependencies:
+    pump "^3.0.0"
+
+get-stream@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-5.1.0.tgz#01203cdc92597f9b909067c3e656cc1f4d3c4dc9"
   integrity sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==
@@ -5877,10 +5962,15 @@ got@^9.6.0:
     to-readable-stream "^1.0.0"
     url-parse-lax "^3.0.0"
 
-graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.2:
+graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.2.2:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
   integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
+
+graceful-fs@^4.1.6, graceful-fs@^4.2.0:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
+  integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
 
 "graceful-readlink@>= 1.0.0":
   version "1.0.1"
@@ -7193,6 +7283,11 @@ lodash@4.17.15, lodash@^4.0.0, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
+lodash@^4.17.20:
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
+  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+
 log-symbols@3.0.0, log-symbols@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-3.0.0.tgz#f3a08516a5dea893336a7dee14d18a1cfdab77c4"
@@ -7451,12 +7546,24 @@ mime-db@1.43.0, "mime-db@>= 1.43.0 < 2":
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.43.0.tgz#0a12e0502650e473d735535050e7c8f4eb4fae58"
   integrity sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==
 
-mime-types@2.1.26, mime-types@^2.1.12, mime-types@^2.1.18, mime-types@^2.1.26, mime-types@~2.1.19, mime-types@~2.1.24:
+mime-db@1.44.0:
+  version "1.44.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.44.0.tgz#fa11c5eb0aca1334b4233cb4d52f10c5a6272f92"
+  integrity sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==
+
+mime-types@2.1.26, mime-types@^2.1.18, mime-types@^2.1.26, mime-types@~2.1.19, mime-types@~2.1.24:
   version "2.1.26"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.26.tgz#9c921fc09b7e149a65dfdc0da4d20997200b0a06"
   integrity sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==
   dependencies:
     mime-db "1.43.0"
+
+mime-types@^2.1.12:
+  version "2.1.27"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.27.tgz#47949f98e279ea53119f5722e0f34e529bec009f"
+  integrity sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==
+  dependencies:
+    mime-db "1.44.0"
 
 mime@1.6.0:
   version "1.6.0"
@@ -7663,7 +7770,7 @@ ms@2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
   integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
 
-ms@^2.0.0, ms@^2.1.1:
+ms@2.1.2, ms@^2.0.0, ms@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
@@ -7970,9 +8077,9 @@ onetime@^2.0.0:
     mimic-fn "^1.0.0"
 
 onetime@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.0.tgz#fff0f3c91617fe62bb50189636e99ac8a6df7be5"
-  integrity sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.2.tgz#d0e96ebb56b07476df1dd9c4806e5237985ca45e"
+  integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
 


### PR DESCRIPTION
This merge requests refactors the test suite to use [Ember Addon Tests](https://github.com/jelhan/ember-addon-tests) instead of [Ember CLI Addon Tests](https://github.com/tomdale/ember-cli-addon-tests).

Ember CLI Addon Tests were unstable and slow. CI pipeline was breaking due to small changes in timing and order of tests. Some tests needed to be executed in different processes to prevent leakage. This caused the tests to be sometimes grouped to not break Ember CLI Addon Tests rather than for readability.

Ember Addon Tests could be seen as a modernized rewrite of Ember CLI Addon Tests utilizing yarn workspaces. It should also provide a better performance but I haven't benchmarked.