### PR TITLE
Remove existing 'none' keyword when applying to source list

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -152,6 +152,16 @@ function appendSourceList(policyObject, directiveName, sourceList) {
     policyObject[directiveName] = policyObject['default-src'] ? policyObject['default-src'].slice() : [];
   }
 
+  if (policyObject[directiveName].includes("'none'")) {
+    if (policyObject[directiveName].length > 1) {
+      throw new Error(
+        `'none' keyword is exclusive in a CSP directive but source list is ${JSON.stringify(value)}`
+      );
+    }
+
+    policyObject[directiveName] = [];
+  }
+
   policyObject[directiveName].push(sourceList);
 }
 

--- a/node-tests/e2e/deliver-test.js
+++ b/node-tests/e2e/deliver-test.js
@@ -8,7 +8,6 @@ const {
   setConfig
 } = require('../utils');
 const path = require('path');
-const { exception } = require('console');
 
 describe('e2e: delivers CSP as configured', function() {
   this.timeout(300000);

--- a/node-tests/e2e/deliver-test.js
+++ b/node-tests/e2e/deliver-test.js
@@ -8,6 +8,7 @@ const {
   setConfig
 } = require('../utils');
 const path = require('path');
+const { exception } = require('console');
 
 describe('e2e: delivers CSP as configured', function() {
   this.timeout(300000);
@@ -244,6 +245,34 @@ describe('e2e: delivers CSP as configured', function() {
         expect(csp).to.match(/script-src[^;]* foo.com/);
         expect(csp).to.match(/script-src[^;]* 0.0.0.0:49741/);
         expect(csp).to.match(/script-src[^;]* localhost:49741/);
+      });
+    });
+
+    it("removes existing 'none' keyword from connect-src", async function() {
+      await setConfig(testProject, {
+        delivery: ['header', 'meta'],
+        policy: {
+          'default-src': ["'self'"],
+          'connect-src': ["'none'"],
+        },
+      });
+      await testProject.startEmberServer({
+        port: '49741',
+      });
+
+      let response = await request({
+        url: 'http://localhost:49741',
+        headers: {
+          'Accept': 'text/html'
+        }
+      });
+
+      let cspInHeader = response.headers['content-security-policy-report-only'];
+      let cspInMetaElement = response.body.match(CSP_META_TAG_REG_EXP)[1];
+      [cspInHeader, cspInMetaElement].forEach((csp) => {
+        expect(csp).to.not.match(/connect-src[^;]* 'none'/);
+        expect(csp).to.match(/connect-src[^;]* ws:\/\/0.0.0.0:49741/);
+        expect(csp).to.match(/connect-src[^;]* ws:\/\/localhost:49741/);
       });
     });
   });

--- a/node-tests/unit/append-source-list-test.js
+++ b/node-tests/unit/append-source-list-test.js
@@ -27,4 +27,13 @@ describe('unit: appendSourceList', function() {
     expect(sourceList['script-src']).to.contain('examples.com');
     expect(sourceList['default-src']).to.deep.equal(["'self'"]);
   });
+
+  it("removes existing 'none' keyword", function() {
+    let sourceList = {
+      'script-src': ["'none'"],
+    };
+
+    appendSourceList(sourceList, 'script-src', 'examples.com');
+    expect(sourceList['script-src']).to.deep.equal(['examples.com']);
+  });
 });


### PR DESCRIPTION
The bug was uncovered in #152 but also affects other parts as shown in the added test.