### PR TITLE
Support live reload and add optional debug log

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,6 +3,7 @@
 'use strict';
 
 const assert = require('assert');
+const debug = require('./utils/debug');
 const fs = require('fs');
 const path = require('path');
 
@@ -186,7 +187,7 @@ function appendSourceList(policyObject, directiveName, sourceList) {
  * @param {string[]} isIndexHtmlForTesting
  * @return {boolean}
  */
-function isIndexHtmlForTesting(existingContent) {
+function getEnvironmentFromRuntimeConfig(existingContent) {
   let encodedRunTimeConfig;
   let configRegExp = /<meta name=".*\/config\/environment" content="(.*)" \/>/;
   for (let content of existingContent) {
@@ -209,13 +210,14 @@ function isIndexHtmlForTesting(existingContent) {
     throw new Error(`Could not decode runtime configuration cause of ${error}`);
   }
 
-  return runTimeConfig.environment === 'test';
+  return runTimeConfig.environment;
 }
 
 module.exports = {
   appendSourceList,
   buildPolicyString,
   calculateConfig,
-  isIndexHtmlForTesting,
+  debug,
+  getEnvironmentFromRuntimeConfig,
   readConfig,
 };

--- a/lib/utils/debug.js
+++ b/lib/utils/debug.js
@@ -1,0 +1,7 @@
+/* eslint-env node */
+
+'use strict';
+
+const createDebug = require('debug');
+
+module.exports = createDebug('ember-cli-content-security-policy');

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "body-parser": "^1.17.0",
     "chalk": "^4.0.0",
+    "debug": "^4.3.1",
     "ember-cli-babel": "^7.17.2",
     "ember-cli-version-checker": "^5.0.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3827,6 +3827,13 @@ debug@^4.1.1:
   dependencies:
     ms "2.1.2"
 
+debug@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
+  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
+  dependencies:
+    ms "2.1.2"
+
 debug@~3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"


### PR DESCRIPTION
Ember CLI Content Security Policy had cached its configuration. This broke live reload because the cache was not invalidated when the addon's configuration file changed. This was reported in #146. Beside causing this bug the caching also added a lot of complexity.

This pull request removes the caching all together. Instead the configuration is calculated whenever it's needed. This has a negative impact on performance. Especially because configuration file is read multiple times - even for the same build. But I don't think the performance impact is noticeable by end-user because the file is still read less than 10 times, it's very small and filesystem caching should speed up subsequent reads.

It also avoid adding `report-uri` to a policy, which is delivered via meta tag. This addresses #148 at least partly.

Additionally it introduces a debug output using [debug](https://www.npmjs.com/package/debug) NPM package. User can opt-in to debug output by setting `DEBUG` environment variable to `ember-cli-content-security-policy`, e.g. `DEBUG=ember-cli-content-security-policy ember build`.

The debug package is used in [ember-auto-import](https://github.com/ef4/ember-auto-import/blob/7610021b3c592bcaa5a649a1d6fa799826f857d3/packages/ember-auto-import/package.json#L42), [embroider](https://github.com/embroider-build/embroider/blob/25d6042c69cbce8355b1a9fa0114447425692e8d/packages/core/package.json#L37) and [ember-data](https://github.com/emberjs/data/blob/4fc1b0774887bb7365113cc655212e10a14ca820/package.json#L71). It seems to be a well established tool in Ember ecosystem.

Closes #146 