### PR TITLE
doc: updated default mixpanel config

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ module.exports = function(environment) {
       'script-src':  ["'self'", "https://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js"],
       // Allow fonts to be loaded from http://fonts.gstatic.com
       'font-src': ["'self'", "http://fonts.gstatic.com"],
-      // Allow data (xhr/websocket) from api.mixpanel.com and custom-api.local
-      'connect-src': ["'self'", "https://api.mixpanel.com", "https://custom-api.local"],
+      // Allow data (xhr/websocket) from api-js.mixpanel.com and custom-api.local
+      'connect-src': ["'self'", "https://api-js.mixpanel.com", "https://custom-api.local"],
       // Allow images from the origin itself (i.e. current domain)
       'img-src': ["'self'"],
       // Allow CSS loaded from https://fonts.googleapis.com


### PR DESCRIPTION
Just tried current Mixpanel with the sample configuration from the README and got the error below. This PR should fix it.

```
Content Security Policy violation:

{
  "csp-report": {
    "document-uri": "http://localhost:4201/authenticated/meetings",
    "referrer": "http://localhost:4201/authenticated/meetings",
    "violated-directive": "connect-src",
    "effective-directive": "connect-src",
    "original-policy": "default-src 'none'; script-src 'self' 'nonce-abcdefg' localhost:4201 0.0.0.0:4201; font-src 'self'; connect-src 'self' ws://localhost:4201 ws://0.0.0.0:4201 http://localhost:4201; img-src 'self'; style-src 'self'; media-src 'self'; report-uri http://localhost:4201/csp-report;",
    "disposition": "report",
    "blocked-uri": "https://api-js.mixpanel.com/track/?verbose=1&ip=1&_=1605511174403",
    "line-number": 140,
    "column-number": 155,
    "source-file": "http://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js",
    "status-code": 200,
    "script-sample": ""
  }
}
```