### PR TITLE
test that addon does not break newly generated projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
     "qunit-dom": "^1.0.0",
     "release-it": "^13.0.2",
     "release-it-lerna-changelog": "^2.0.0",
-    "request": "^2.88.0"
+    "request": "^2.88.0",
+    "semver": "^7.3.2"
   },
   "engines": {
     "node": "10.* || >= 12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9288,6 +9288,11 @@ semver@^7.1.3:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.2.2.tgz#d01432d74ed3010a20ffaf909d63a691520521cd"
   integrity sha512-Zo84u6o2PebMSK3zjJ6Zp5wi8VnQZnEaCP13Ul/lt1ANsLACxnJxq4EEm1PY94/por1Hm9+7xpIswdS5AkieMA==
 
+semver@^7.3.2:
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
+  integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
+
 send@0.17.1:
   version "0.17.1"
   resolved "https://registry.yarnpkg.com/send/-/send-0.17.1.tgz#c1d8b059f7900f7466dd4938bdc44e11ddb376c8"


### PR DESCRIPTION
Assert that tests are passing for untouched applications and addons generated by Ember CLI blueprints after installing the addon. These changes are pulled out of #158.