### PR TITLE
Fix typo `form-ancestors` -> `frame-ancestors` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ type directiveName =
   | 'sandbox'
   // Navigation Directives
   | 'form-action'
-  | 'form-ancestors'
+  | 'frame-ancestors'
   | 'navigate-to'
   // Reporting Directives
   | 'report-uri'


### PR DESCRIPTION
I believe `form-ancestors` should actually be `frame-ancestors` per: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#navigation_directives