### PR TITLE
Run scenarios with expected Ember CLI version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,4 +181,4 @@ jobs:
         EMBER_CLI_VERSION: ${{ matrix.ember-cli }}
 
     - name: Test
-      run: yarn test:node
+      run: mocha node-tests/**/*-test.js


### PR DESCRIPTION
`yarn test:node` runs the scenarios with the Ember CLI version installed in the package itself. It does _not_ pick up the global Ember CLI version.

[ember-addon-tests](https://github.com/jelhan/ember-addon-tests) uses the `ember` binary available on shell to create new projects. Yarn adds `node_modules/.bin` to the `$PATH`, which overrules all binaries installed globally. Therefore executing the tests with `yarn test:node` will always use the Ember CLI version installed in the package and not the one installed globally.