### PR TITLE
Fastboot instance initializer throws if reportOnly config is false

### DIFF
--- a/fastboot/instance-initializers/content-security-policy.js
+++ b/fastboot/instance-initializers/content-security-policy.js
@@ -9,7 +9,9 @@ function readAddonConfig(appInstance) {
   //       if already available through CSP meta element
   assert(
     'Required configuration is available at run-time',
-    addonConfig && addonConfig['reportOnly'] && addonConfig['policy']
+    addonConfig &&
+      Object.prototype.hasOwnProperty.call(addonConfig, 'reportOnly') &&
+      Object.prototype.hasOwnProperty.call(addonConfig, 'policy')
   );
 
   return config['ember-cli-content-security-policy'];

--- a/fastboot/instance-initializers/content-security-policy.js
+++ b/fastboot/instance-initializers/content-security-policy.js
@@ -11,7 +11,7 @@ function readAddonConfig(appInstance) {
     'Required configuration is available at run-time',
     typeof addonConfig === 'object' &&
       typeof addonConfig.reportOnly === 'boolean' &&
-      typeof addonConfig.policy === 'object'
+      typeof addonConfig.policy === 'string'
   );
 
   return config['ember-cli-content-security-policy'];

--- a/fastboot/instance-initializers/content-security-policy.js
+++ b/fastboot/instance-initializers/content-security-policy.js
@@ -9,9 +9,9 @@ function readAddonConfig(appInstance) {
   //       if already available through CSP meta element
   assert(
     'Required configuration is available at run-time',
-    addonConfig &&
-      Object.prototype.hasOwnProperty.call(addonConfig, 'reportOnly') &&
-      Object.prototype.hasOwnProperty.call(addonConfig, 'policy')
+    typeof addonConfig === 'object' &&
+      typeof addonConfig.reportOnly === 'boolean' &&
+      typeof addonConfig.policy === 'object'
   );
 
   return config['ember-cli-content-security-policy'];

--- a/node-tests/e2e/fastboot-support-test.js
+++ b/node-tests/e2e/fastboot-support-test.js
@@ -104,6 +104,7 @@ describe('e2e: fastboot integration', function () {
         },
       });
 
+      expect(response.statusCode).to.equal(200);
       expect(response.headers).to.include.key(
         'content-security-policy-report-only'
       );
@@ -122,7 +123,7 @@ describe('e2e: fastboot integration', function () {
       await removeConfig(testProject);
     });
 
-    it.only('sets CSP header if served via FastBoot', async function () {
+    it('sets CSP header if served via FastBoot', async function () {
       let response = await request({
         url: 'http://localhost:49742',
         headers: {
@@ -130,6 +131,7 @@ describe('e2e: fastboot integration', function () {
         },
       });
 
+      expect(response.statusCode).to.equal(200);
       expect(response.headers).to.include.key('content-security-policy');
     });
   });

--- a/node-tests/e2e/fastboot-support-test.js
+++ b/node-tests/e2e/fastboot-support-test.js
@@ -110,6 +110,30 @@ describe('e2e: fastboot integration', function () {
     });
   });
 
+  describe('scenario: with reportOnly = false', function () {
+    before(async function () {
+      await setConfig(testProject, { reportOnly: false });
+      await testProject.runEmberCommand('build');
+      await startServer();
+    });
+
+    after(async function () {
+      await stopServer();
+      await removeConfig(testProject);
+    });
+
+    it.only('sets CSP header if served via FastBoot', async function () {
+      let response = await request({
+        url: 'http://localhost:49742',
+        headers: {
+          Accept: 'text/html',
+        },
+      });
+
+      expect(response.headers).to.include.key('content-security-policy');
+    });
+  });
+
   describe('scenario: disabled', function () {
     before(async function () {
       await setConfig(testProject, { enabled: false });


### PR DESCRIPTION
The current behaviour makes it impossible to disable `reportOnly` mode, we actually want to ensure the configuration is properly defined, not that it's true.