### PR TITLE
fix: pass environment into readConfig

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -37,7 +37,7 @@ module.exports = {
     run: function (options) {
       let { environment, reportUri } = options;
       let { project, ui } = this;
-      let ownConfig = readConfig(project);
+      let ownConfig = readConfig(project, environment);
       let runConfig = project.config(environment);
       let { reportOnly, policy } = calculateConfig(
         environment,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -49,6 +49,7 @@ const getConfigPath = function (projectPkg, projectRoot) {
  * Returns an empty object if that file does not exist.
  *
  * @param {string} project
+ * @param {string} environment
  * @return {object}
  */
 const readConfig = function (project, environment) {

--- a/node-tests/e2e/cli-command-test.js
+++ b/node-tests/e2e/cli-command-test.js
@@ -39,4 +39,39 @@ describe('e2e: CLI command csp-headers', function () {
       "default-src 'self'; script-src 'self' 'unsafe-inline';"
     );
   });
+
+  describe('passes environment into the configuration', function () {
+    beforeEach(async function () {
+      await setConfig(testProject, {
+        policy: {
+          'default-src': "'self'",
+          'script-src':
+            "{{\"'self'\" + (environment === 'development' ? \" 'unsafe-inline'\" : '')}}",
+          'font-src':
+            "{{\"'self'\" + (environment === 'production' ? \" http://fonts.gstatic.com\" : '')}}",
+        },
+      });
+    });
+
+    it('passes development as default', async function () {
+      let { stdout } = await testProject.runEmberCommand(
+        'csp-headers',
+        '--silent'
+      );
+      expect(stdout).to.equal(
+        "default-src 'self'; script-src 'self' 'unsafe-inline'; font-src 'self';"
+      );
+    });
+
+    it('passes specified environment', async function () {
+      let { stdout } = await testProject.runEmberCommand(
+        'csp-headers',
+        '--silent',
+        '--environment=production'
+      );
+      expect(stdout).to.equal(
+        "default-src 'self'; script-src 'self'; font-src 'self' http://fonts.gstatic.com;"
+      );
+    });
+  });
 });

--- a/node-tests/utils.js
+++ b/node-tests/utils.js
@@ -4,9 +4,15 @@ const fs = require('fs');
 const CONFIG_PATH = 'config/content-security-policy.js';
 const CSP_META_TAG_REG_EXP = /<meta http-equiv="Content-Security-Policy" content="(.*)">/i;
 
+function parseExpressions(config) {
+  return config.replace(/"{{.*}}"/gs, (match) =>
+    match.replace(/"{{|}}"/g, '').replace(/\\"/g, '"')
+  );
+}
+
 async function setConfig(testProject, config) {
-  let content = `module.exports = function() { return ${JSON.stringify(
-    config
+  let content = `module.exports = function(environment) { return ${parseExpressions(
+    JSON.stringify(config)
   )}; }`;
 
   await testProject.writeFile(CONFIG_PATH, content);


### PR DESCRIPTION
Noticed a small bug while using the csp-headers command: environment was not being passed into the config function.

This PR fixes that!