### PR TITLE
Fixing tiny typo in deprecation-warning

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -90,7 +90,7 @@ function calculateConfig(environment, ownConfig, runConfig, ui) {
     'Configuring ember-cli-content-security-policy using `contentSecurityPolicy`, ' +
       '`contentSecurityPolicyHeader` and `contentSecurityPolicyMeta` keys in `config/environment.js` ' +
       'is deprecate and will be removed in v3.0.0. ember-cli-content-security-policy is now configured ' +
-      'using `config/content-security-polic.js`. Please find detailed information about this change ' +
+      'using `config/content-security-policy.js`. Please find detailed information about this change ' +
       'and recommended migration steps in deprecation guide at ' +
       'https://github.com/rwjblue/ember-cli-content-security-policy/blob/master/DEPRECATIONS.md.',
     !runConfig.contentSecurityPolicy ||


### PR DESCRIPTION
Here is a ridiculous PR to fix a small typo included in the warning message. Thanks!