### PR TITLE
fix: Example allows manifest from self

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ module.exports = function (environment) {
       'img-src': ["'self'"],
       // Allow CSS loaded from https://fonts.googleapis.com
       'style-src': ["'self'", 'https://fonts.googleapis.com'],
+      // Allow manifest from the origin itself (i.e. current domain)
+      'manifest-src': ["'self'"],
       // Omit `media-src` from policy
       // Browser will fallback to default-src for media resources (which is 'none', see above)
       'media-src': null,


### PR DESCRIPTION
- Given example is quite handy starting copy&paste.
- Unfortunatelly for Chrome with modern Ember apps it gives:

```
assessment:1 Refused to load manifest from 'http://localhost:4200/manifest.webmanifest' because it violates the following Content Security Policy directive: "default-src 'none'". Note that 'manifest-src' was not explicitly set, so 'default-src' is used as a fallback.
```

- This patch makes the README as a nicer starting point.